### PR TITLE
Do not deploy standard kyverno policies

### DIFF
--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -3,7 +3,7 @@ fullnameOverride: kyverno
 namespace:
 # Supported- default/restricted/privileged/custom
 # For more info- https://kyverno.io/policies/pod-security
-podSecurityStandard: default
+podSecurityStandard: custom
 # Policies to include when podSecurityStandard is custom
 podSecurityPolicies: []
 # Supported values- `audit`, `enforce`


### PR DESCRIPTION
By default, kyverno deploys some `ClusterPolicy` resources for standard checks. We will manage policies separately, so don't deploy them as they override our policies