### PR TITLE
Allow port 8000 for use by kyverno-svc-metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add annotation which sets `ludacris` as app owner.
+- Allow ingress on port 8000 for scraping metrics.
 
 ## [0.3.0] - 2021-07-09
 

--- a/helm/kyverno/templates/networkpolicy.yaml
+++ b/helm/kyverno/templates/networkpolicy.yaml
@@ -15,6 +15,8 @@ spec:
   - ports:
     - port: 443
       protocol: TCP
+    - port: 8000
+      protocol: TCP
     - port: 9443
       protocol: TCP
   policyTypes:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18354

Kyverno exposes metrics on port 8000, where the `kyverno-svc-metrics` service routes traffic

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
