### PR TITLE
Disable monitoring by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Disable policy-reporter monitoring (ServiceMonitors) by default.
+
 ## [0.7.1] - 2021-12-17
 
 ### Removed

--- a/helm/kyverno/Chart.yaml
+++ b/helm/kyverno/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.5.1
 annotations:
   application.giantswarm.io/team: team-honeybadger
-  config.giantswarm.io/version: 1.x.x
+  config.giantswarm.io/version: "enable-polrep-monitoring"
 dependencies:
   - name: policy-reporter
     version: 1.12.5

--- a/helm/kyverno/Chart.yaml
+++ b/helm/kyverno/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.5.1
 annotations:
   application.giantswarm.io/team: team-honeybadger
-  config.giantswarm.io/version: "enable-polrep-monitoring"
+  config.giantswarm.io/version: 1.x.x
 dependencies:
   - name: policy-reporter
     version: 1.12.5

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -87,5 +87,5 @@ policy-reporter:
       kyverno: true
 
   monitoring:
-    enabled: true
+    enabled: false
     namespace: monitoring


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/20446
enabling monitoring makes assumptions in the underlying charts that the Prometheus CRD for ServiceMonitors is installed and the namespace exists. This PR disables monitoring by default. I enable it for our MCs in `config`

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
