### PR TITLE
Bump AppVersion to 1.6.2

### DIFF
--- a/helm/kyverno/Chart.yaml
+++ b/helm/kyverno/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.5.1
+appVersion: v1.6.2
 annotations:
   application.giantswarm.io/team: team-honeybadger
   config.giantswarm.io/version: 1.x.x


### PR DESCRIPTION
Missed this in the update. Image version is correct, but app version is reported incorrectly
### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
