### PR TITLE
Improve Kyverno resilience (set RCR limit and PriorityClass)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use pre-install CRD install Job to remove storage version `v1alpha1` for several Kyverno CRDs.
 - Set Kyverno to use the `giantswarm-critical` PriorityClass.
 - Limit maximum ReportChangeRequests per namespace to 100.
+- Split PolicyReports into one report per policy to support the RCR limiting and avoid cases where a report doesn't fit into etcd.
 
 ## [0.10.3] - 2022-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `kyverno` to upstream version 1.7.2 / chart version 2.5.2.
+- Use pre-install CRD install Job to remove storage version `v1alpha1` for several Kyverno CRDs.
+
 ## [0.10.3] - 2022-08-09
 
 ### Changed
 
-- Fix Circle CI job name for puhsing to app collection.
+- Fix Circle CI job name for pushing to app collection.
 
 ## [0.10.2] - 2022-08-05
 
 ### Changed
 
 - Update `policy-reporter` to version 2.9.1 / app version 2.6.1.
-- Update `kyverno` to upstream version 1.7.2 / chart version 2.5.2.
-- Use pre-install CRD install Job to remove storage version `v1alpha1` for several Kyverno CRDs.
 
 ## [0.10.1] - 2022-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `kyverno` to upstream version 1.7.2 / chart version 2.5.2.
 - Use pre-install CRD install Job to remove storage version `v1alpha1` for several Kyverno CRDs.
 - Set Kyverno to use the `giantswarm-critical` PriorityClass.
-- Limit maximum ReportChangeRequests per namespace to 500.
+- Limit maximum ReportChangeRequests per namespace to 100.
 
 ## [0.10.3] - 2022-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update `kyverno` to upstream version 1.7.2 / chart version 2.5.2.
 - Use pre-install CRD install Job to remove storage version `v1alpha1` for several Kyverno CRDs.
+- Set Kyverno to use the `giantswarm-critical` PriorityClass.
+- Limit maximum ReportChangeRequests per namespace to 500.
 
 ## [0.10.3] - 2022-08-09
 
@@ -41,17 +43,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Change to using `maxUnavailable` to match existing configs
+- Change to using `maxUnavailable` to match existing configs.
 
 ## [0.9.0] - 2022-03-14
 
 ### Changed
 
-- Enable Pod Disruption Budget by default
+- Enable Pod Disruption Budget by default.
 
 ## [0.8.1] - 2022-02-18
 
-- make PDB version conditional based on available API
+- Make PDB version conditional based on available API.
 
 ## [0.8.0] - 2022-02-03
 

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -52,7 +52,8 @@ kyverno:
     serviceAccount:
       name: "kyverno"  # Added so that we can create a PSP allowing emptyDir and seccomp profiles. Can be removed when PSPs are removed.
   extraArgs:
-    - --maxReportChangeRequests=50
+    - -maxReportChangeRequests=100
+    - -splitPolicyReport=true
 
 # Additional options defined in charts/policy-reporter/values.yaml. Upstream docs: https://github.com/kyverno/policy-reporter
 policy-reporter:

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -45,13 +45,14 @@ kyverno:
   podDisruptionBudget:
     maxUnavailable: 1
     minAvailable: ""
+  priorityClassName: "giantswarm-critical"
   psp:
     enabled: true
   rbac:
     serviceAccount:
       name: "kyverno"  # Added so that we can create a PSP allowing emptyDir and seccomp profiles. Can be removed when PSPs are removed.
   extraArgs:
-    - -maxReportChangeRequests=50
+    - --maxReportChangeRequests=50
 
 # Additional options defined in charts/policy-reporter/values.yaml. Upstream docs: https://github.com/kyverno/policy-reporter
 policy-reporter:

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -50,6 +50,8 @@ kyverno:
   rbac:
     serviceAccount:
       name: "kyverno"  # Added so that we can create a PSP allowing emptyDir and seccomp profiles. Can be removed when PSPs are removed.
+  extraArgs:
+    - -maxReportChangeRequests=500
 
 # Additional options defined in charts/policy-reporter/values.yaml. Upstream docs: https://github.com/kyverno/policy-reporter
 policy-reporter:

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -51,7 +51,7 @@ kyverno:
     serviceAccount:
       name: "kyverno"  # Added so that we can create a PSP allowing emptyDir and seccomp profiles. Can be removed when PSPs are removed.
   extraArgs:
-    - -maxReportChangeRequests=500
+    - -maxReportChangeRequests=50
 
 # Additional options defined in charts/policy-reporter/values.yaml. Upstream docs: https://github.com/kyverno/policy-reporter
 policy-reporter:


### PR DESCRIPTION
This PR does three things:
- sets the PriorityClass to `giantswarm-critical` which exists in both MCs and WCs
- sets the flag introduced in https://github.com/kyverno/kyverno/pull/4148 to limit the maximum number of ReportChangeRequests (RCRs) to 100*
- sets the `splitPolicyReport` flag to split reports more granularly, since some are too large to fit in `etcd` and without this flag set, the RCR limiting seems not to function as reliably.

*note: in testing this PR, the flag does not seem to provide completely bulletproof protection. For reasons I don't understand yet, the limit can be surpassed, and I've not been able to reproduce the throttling behavior for larger values (e.g. 500 or 1000). I'm setting to 100 in this PR out of an abundance of caution. The value can be overridden by users at their discretion, and we may update it once a more optimal value has been established

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
