### PR TITLE
Increase max QPS and burst rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Increase maximum sustained and burst Kubernetes client rate limits to 75 and 150 requests/second, respectively.
+
 ## [0.11.0] - 2022-08-17
 
 ### Changed

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -52,6 +52,8 @@ kyverno:
     serviceAccount:
       name: "kyverno"  # Added so that we can create a PSP allowing emptyDir and seccomp profiles. Can be removed when PSPs are removed.
   extraArgs:
+    - -clientRateLimitQPS=75
+    - -clientRateLimitBurst=150
     - -maxReportChangeRequests=100
     - -splitPolicyReport=true
 


### PR DESCRIPTION
From suggestions in https://github.com/giantswarm/giantswarm/issues/22650, raises the rate limit for the Kubernetes client used by Kyverno internally so that it will not limit itself as heavily.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
