### PR TITLE
Don't remove the 'crd-install' job when the job fails, so that we can investigate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix broken links in documentation.
+- Don't remove the `crd-install` job when the job fails, so that we can investigate.
 
 ## [0.11.6] - 2022-10-19
 

--- a/helm/kyverno/templates/_helpers.tpl
+++ b/helm/kyverno/templates/_helpers.tpl
@@ -135,7 +135,7 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
 
 {{- define "kyverno-stack.CRDInstallAnnotations" -}}
 "helm.sh/hook": "pre-install,pre-upgrade"
-"helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+"helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 {{- end -}}
 
 {{- define "kyverno-stack.selectorLabels" -}}


### PR DESCRIPTION
kyverno is failing because the `ServiceAccount` is missing. My guess is that after the job has failed for some reason, some of the resources are deleted, and the job will fail when retrying. I think we need to keep resources around when the job fails, because that way we can investigate what happened.

```
Type     Reason        Age                   From            Message
  ----     ------        ----                  ----            -------
  Warning  FailedCreate  60s (x51 over 4h35m)  job-controller  Error creating: pods "kyverno-crd-install-" is forbidden: error looking up service account kyverno/kyverno-crd-install: serviceaccount "kyverno-crd-install" not found
```

### Checklist

- [X] Update changelog in CHANGELOG.md.
- [X] Make sure `values.yaml` and `values.schema.json` are valid.
