### PR TITLE
Updates exceptionNamespace args for policyexceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Don't push to `openstack-app-collection`.
 - Rename `vmware-app-collection` to `vsphere-app-collection`.
-- Removed `exceptionNamespace` as `extraArgs` from `kyverno` helm values.
+- Consider PolicyExceptions from all namespaces.
 
 ## [0.14.1] - 2023-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Removed `exceptionNamespace` as `extraArgs` from `kyverno` helm values.
+
 ## [0.14.0] - 2023-02-23
 
 ### Changed

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -87,7 +87,6 @@ kyverno:
     - -clientRateLimitBurst=150
     - -enablePolicyException=true
     - --loggingFormat=text
-    - --exceptionNamespace=default
 
   cleanupController:
     # -- Enable cleanup controller.

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -87,7 +87,7 @@ kyverno:
     - -clientRateLimitBurst=150
     - -enablePolicyException=true
     - --loggingFormat=text
-    - --exceptionNamespace={{ include "kyverno.namespace" . }}
+    - --exceptionNamespace=default
 
   cleanupController:
     # -- Enable cleanup controller.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/26389

Updates `exceptionNamespace` list to set the `namespace` where `PolicyException` must be permitted.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
