### PR TITLE
Include PolicyException for chart-operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add PolicyException for Giant Swarm's `chart-operator`.
+
 ## [0.14.5] - 2023-05-16
 
 ### Added

--- a/helm/kyverno/templates/core-policies/chart-operator-polex.yaml
+++ b/helm/kyverno/templates/core-policies/chart-operator-polex.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.policyExceptions.enableChartOperatorPolex }}
+apiVersion: kyverno.io/v2alpha1
+kind: PolicyException
+metadata:
+  name: kyverno-app-chart-operator-policy-exception
+  namespace: giantswarm
+  labels:
+    {{- include "kyverno-stack.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
+spec:
+  exceptions:
+  - policyName: disallow-host-ports
+    ruleNames:
+    - host-ports-none
+    - autogen-host-ports-none
+  - policyName: disallow-host-namespaces
+    ruleNames:
+    - host-namespaces
+    - autogen-host-namespaces
+
+  match:
+    any:
+    - resources:
+        kinds:
+        - Deployment
+        - ReplicaSet
+        - Pod
+        namespaces:
+        - giantswarm
+        names:
+        - chart-operator*
+{{- end -}}

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -36,6 +36,8 @@ policyExceptions:
   polexPolicyMessage: >-
     PolicyExceptions are not allowed to be created in the {{ request.namespace }} namespace.
     Please contact a cluster administrator for assistance.
+  # Deploy a PolicyException for chart-operator (required for Giant Swarm clusters).
+  enableChartOperatorPolex: true
 
 # Delete orphaned webhooks on chart uninstall
 # This will be removed in Kyverno 1.10 release.


### PR DESCRIPTION
As long as we use `chart-operator` to deploy Apps, Kyverno can't possibly exist before it. This means `chart-operator` can't ship its own exception, and if chart-operator gets rejected then no other apps containing future exceptions can deploy. So we include the exception here.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
