### PR TITLE
Create policy to forbid wildcards in policy match statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add ClusterPolicy `restrict-policy-kind-wildcards` to prevent running (Cluster)Policies which match all API Kinds.
+
 ## [0.14.5] - 2023-05-16
 
 ### Added

--- a/helm/kyverno/templates/core-policies/restrict-polex-namespaces.yaml
+++ b/helm/kyverno/templates/core-policies/restrict-polex-namespaces.yaml
@@ -3,6 +3,8 @@ apiVersion: kyverno.io/v2beta1
 kind: ClusterPolicy
 metadata:
   name: restrict-polex-namespaces
+  labels:
+    {{- include "kyverno-stack.labels" . | nindent 4 }}
   annotations:
     policies.kyverno.io/title: Restrict PolicyException Namespaces
     policies.kyverno.io/category: Security

--- a/helm/kyverno/templates/core-policies/restrict-policy-kind-wildcards.yaml
+++ b/helm/kyverno/templates/core-policies/restrict-policy-kind-wildcards.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.policyExceptions.enableWildcardMatchPolicy }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -46,4 +47,4 @@ spec:
             - key: "{{`{{ contains(request.object.spec.rules[].match[].all[].resources[].kinds[], '*') }}`}}"
               operator: Equals
               value: true
-
+{{- end }}

--- a/helm/kyverno/templates/core-policies/restrict-policy-kind-wildcards.yaml
+++ b/helm/kyverno/templates/core-policies/restrict-policy-kind-wildcards.yaml
@@ -3,6 +3,8 @@ apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: restrict-policy-kind-wildcards
+  labels:
+    {{- include "kyverno-stack.labels" . | nindent 4 }}
   annotations:
     policies.kyverno.io/title: Restrict Wildcard in Kinds Matched by Policies
     policies.kyverno.io/category: Security, Best Practices
@@ -18,6 +20,7 @@ metadata:
       significant load on Kyverno, and is almost certainly not necessary for a particular policy.
       Please explicitly list the Kinds to be matched by a (Cluster)Policy, or consider whether
       native Kubernetes RBAC can be used instead for policies which truly apply to every type.
+    {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
 spec:
   validationFailureAction: Enforce
   background: true

--- a/helm/kyverno/templates/core-policies/restrict-policy-kind-wildcards.yaml
+++ b/helm/kyverno/templates/core-policies/restrict-policy-kind-wildcards.yaml
@@ -1,0 +1,49 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-policy-kind-wildcards
+  annotations:
+    policies.kyverno.io/title: Restrict Wildcard in Kinds Matched by Policies
+    policies.kyverno.io/category: Security, Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Policy, ClusterPolicy
+    kyverno.io/kyverno-version: 1.6.2
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.23"
+    policies.kyverno.io/description: >-
+      Using wildcards ('*') in a Kyverno (Cluster)Policy matches all possible API types.
+      This includes cluster-critical resources, informational events, and internal API types
+      used by running workloads. Sending all Kinds through admission review can create
+      significant load on Kyverno, and is almost certainly not necessary for a particular policy.
+      Please explicitly list the Kinds to be matched by a (Cluster)Policy, or consider whether
+      native Kubernetes RBAC can be used instead for policies which truly apply to every type.
+spec:
+  validationFailureAction: Enforce
+  background: true
+  rules:
+    - name: wildcard-kinds
+      match:
+        any:
+        - resources:
+            kinds:
+              - Policy
+              - ClusterPolicy
+      preconditions:
+        all:
+        - key: "{{`{{ request.operation || 'BACKGROUND' }}`}}"
+          operator: NotEquals
+          value: DELETE
+      validate:
+        message: >-
+          Using a wildcard ('*') in a Policy or ClusterPolicy kinds match causes excessive admission review load and is generally not necessary.
+          Instead, (Cluster)Policies should explicitly match only the resource types to which they are truly relevant.
+        deny:
+          conditions:
+            any:
+            - key: "{{`{{ contains(request.object.spec.rules[].match[].any[].resources[].kinds[], '*') }}`}}"
+              operator: Equals
+              value: true
+            - key: "{{`{{ contains(request.object.spec.rules[].match[].all[].resources[].kinds[], '*') }}`}}"
+              operator: Equals
+              value: true
+

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -37,6 +37,10 @@ policyExceptions:
     PolicyExceptions are not allowed to be created in the {{ request.namespace }} namespace.
     Please contact a cluster administrator for assistance.
 
+  # Deploy a ClusterPolicy which prevents other Policies and ClusterPolicies from matching all resource types.
+  # Matching all (*) kinds results in excessive and unnecessary admission review load.
+  enableWildcardMatchPolicy: true
+
 # Delete orphaned webhooks on chart uninstall
 # This will be removed in Kyverno 1.10 release.
 webhooksCleanup:


### PR DESCRIPTION
If a Policy or ClusterPolicy matches all resource kinds (`"*"`), it almost certainly matches more than intended. This also sends tons of unnecessary resources through kyverno admission review, which is bad for kyverno and bad for the cluster.

This policy forbids using wildcards in a Policy or ClusterPolicy match.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
