### PR TITLE
Allow PolicyExceptions in flux-giantswarm namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Allow PolicyExceptions in `flux-giantswarm` namespace.
+
 ## [0.14.9] - 2023-06-26
 
 ### Added
@@ -121,7 +125,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `CiliumNetworkPolicy` for the CRD install job. 
+- Added `CiliumNetworkPolicy` for the CRD install job.
 
 ## [0.11.7] - 2022-11-07
 

--- a/helm/kyverno/templates/core-policies/restrict-polex-namespaces.yaml
+++ b/helm/kyverno/templates/core-policies/restrict-polex-namespaces.yaml
@@ -43,6 +43,7 @@ spec:
             operator: AnyNotIn
             value:
             - giantswarm
+            - flux-giantswarm
             - kube-system
             {{- range .Values.policyExceptions.allowedPolexNamespaces }}
             - {{ . }}


### PR DESCRIPTION
Allow PolicyExceptions to exist in `flux-giantswarm` namespace as well.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
