### PR TITLE
Add chart-operator ServiceAccount exception for PolEx creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added Policy Exceptions for `aws-cloud-controller-manager`, `aws-ebs-csi-driver`, `azure-cloud-controller-manager` and `cilium`.
-- Add PolicyException for `chart-operator` ServiceAccount.
+- Add Policy Exception for `chart-operator` ServiceAccount.
+- Change `psp.enabled` value to `global.podSecurityStandards.enforced`
 
 ## [0.15.2] - 2023-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added Policy Exceptions for `aws-cloud-controller-manager`, `aws-ebs-csi-driver`, `azure-cloud-controller-manager` and `cilium`.
+- Add PolicyException for `chart-operator` ServiceAccount.
 
 ## [0.15.2] - 2023-09-01
 

--- a/helm/kyverno/templates/core-policies/chart-operator-polex.yaml
+++ b/helm/kyverno/templates/core-policies/chart-operator-polex.yaml
@@ -18,7 +18,6 @@ spec:
     ruleNames:
     - host-namespaces
     - autogen-host-namespaces
-
   match:
     any:
     - resources:
@@ -30,4 +29,32 @@ spec:
         - giantswarm
         names:
         - chart-operator*
+---
+apiVersion: kyverno.io/v2alpha1
+kind: PolicyException
+metadata:
+  name: kyverno-app-chart-operator-sa-policy-exception
+  namespace: giantswarm
+  labels:
+    {{- include "kyverno-stack.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
+spec:
+  background: false
+  exceptions:
+  - policyName: restrict-polex-namespaces
+    ruleNames:
+    - restrict-namespaces
+  match:
+    any:
+    - resources:
+        kinds:
+        - PolicyException
+        operations:
+        - CREATE
+        - UPDATE
+      subjects:
+      - kind: ServiceAccount
+        name: chart-operator
+        namespace: giantswarm
 {{- end -}}

--- a/helm/kyverno/templates/core-policies/chart-operator-polex.yaml
+++ b/helm/kyverno/templates/core-policies/chart-operator-polex.yaml
@@ -19,7 +19,7 @@ spec:
     - host-namespaces
     - autogen-host-namespaces
   match:
-    any:
+    all:
     - resources:
         kinds:
         - Deployment
@@ -46,7 +46,7 @@ spec:
     ruleNames:
     - restrict-namespaces
   match:
-    any:
+    all:
     - resources:
         kinds:
         - PolicyException

--- a/helm/kyverno/templates/crd-install/crd-psp.yaml
+++ b/helm/kyverno/templates/crd-install/crd-psp.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.crds.install }}
-{{- if .Values.psp.enabled }}
+{{- if not .Values.global.podSecurityStandards.enforced }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/helm/kyverno/templates/kyverno-psp/kyverno-psp-rbac.yaml
+++ b/helm/kyverno/templates/kyverno-psp/kyverno-psp-rbac.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.psp.enabled }}
+{{- if not .Values.global.podSecurityStandards.enforced }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/helm/kyverno/templates/policyreporter-psp/policyreporter-psp-rbac.yaml
+++ b/helm/kyverno/templates/policyreporter-psp/policyreporter-psp-rbac.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.psp.enabled }}
+{{- if not .Values.global.podSecurityStandards.enforced }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/helm/kyverno/values.schema.json
+++ b/helm/kyverno/values.schema.json
@@ -45,6 +45,19 @@
                 }
             }
         },
+        "global": {
+            "type": "object",
+            "properties": {
+                "podSecurityStandards": {
+                    "type": "object",
+                    "properties": {
+                        "enforced": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
         "image": {
             "type": "object",
             "properties": {
@@ -2224,6 +2237,15 @@
                         "type": "string"
                     }
                 },
+                "enableAwsCloudControllerManagerPolex": {
+                    "type": "boolean"
+                },
+                "enableAwsEbsCsiDriverPolex": {
+                    "type": "boolean"
+                },
+                "enableAzureCloudControllerManagerPolex": {
+                    "type": "boolean"
+                },
                 "enableChartOperatorPolex": {
                     "type": "boolean"
                 },
@@ -2241,23 +2263,6 @@
                 },
                 "polexPolicyMessage": {
                     "type": "string"
-                },
-                "enableAwsCloudControllerManagerPolex": {
-                    "type": "boolean"
-                },
-                "enableAwsEbsCsiDriverPolex": {
-                    "type": "boolean"
-                },
-                "enableAzureCloudControllerManagerPolex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "psp": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
                 }
             }
         },

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -1,3 +1,9 @@
+# Create PSPs for every component including the CRD install job
+global:
+  podSecurityStandards:
+    enforced: false
+
+# Create CiliumNetworkPolicy
 ciliumNetworkPolicy:
   enabled: false
 
@@ -14,10 +20,6 @@ crds:
 
 image:
   registry: docker.io
-
-# Create PSPs for every component including the CRD install job
-psp:
-  enabled: true
 
 # VerticalPodAutoscaler settings for individual controllers
 verticalPodAutoscaler:


### PR DESCRIPTION
Excempts the chart-operator service accounts from the restrict-polex-namespaces policy.