### PR TITLE
Add PolicyException for Azure cloud node manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added Policy Exceptions for `azure-cloud-node-manager`.
+
 ## [0.16.2] - 2023-11-16
 
 ### Changed

--- a/helm/kyverno/templates/core-policies/azure-cloud-node-manager-polex.yaml
+++ b/helm/kyverno/templates/core-policies/azure-cloud-node-manager-polex.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.policyExceptions.enableAzureCloudControllerManagerPolex }}
+apiVersion: kyverno.io/v2alpha1
+kind: PolicyException
+metadata:
+  name: kyverno-app-azure-cloud-controller-policy-exception 
+  namespace: giantswarm
+  labels:
+    {{- include "kyverno-stack.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
+spec:
+  exceptions:
+  - policyName: disallow-host-path
+    ruleNames:
+    - host-path
+    - autogen-host-path
+  - policyName: restrict-volume-types
+    ruleNames:
+    - restricted-volumes
+    - autogen-restricted-volumes
+  - policyName: require-run-as-nonroot
+    ruleNames:
+    - run-as-non-root 
+    - autogen-run-as-non-root
+  - policyName: restrict-seccomp-strict
+    ruleNames:
+    - check-seccomp-strict
+    - autogen-check-seccomp-strict
+  - policyName: disallow-capabilities-strict
+    ruleNames:
+    - adding-capabilities-strict
+    - autogen-adding-capabilities-strict
+    - require-drop-all
+    - autogen-require-drop-all
+  - policyName: require-run-as-non-root-user
+    ruleNames:
+    - run-as-non-root-user
+    - autogen-run-as-non-root-user
+  - policyName: disallow-host-namespaces
+    ruleNames:
+    - host-namespaces
+    - autogen-host-namespaces
+  match:
+    any:
+    - resources:
+        kinds:
+        - DaemonSet
+        - ReplicaSet
+        - Pod
+        namespaces:
+        - kube-system
+        names:
+        - azure-cloud-controller-manager*
+{{- end }}

--- a/helm/kyverno/templates/core-policies/azure-cloud-node-manager-polex.yaml
+++ b/helm/kyverno/templates/core-policies/azure-cloud-node-manager-polex.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.policyExceptions.enableAzureCloudControllerManagerPolex }}
+{{- if .Values.policyExceptions.enableAzureCloudNodeManagerPolex }}
 apiVersion: kyverno.io/v2alpha1
 kind: PolicyException
 metadata:
-  name: kyverno-app-azure-cloud-controller-policy-exception 
+  name: kyverno-app-azure-cloud-node-manager-policy-exception
   namespace: giantswarm
   labels:
     {{- include "kyverno-stack.labels" . | nindent 4 }}
@@ -10,17 +10,9 @@ metadata:
     {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
 spec:
   exceptions:
-  - policyName: disallow-host-path
-    ruleNames:
-    - host-path
-    - autogen-host-path
-  - policyName: restrict-volume-types
-    ruleNames:
-    - restricted-volumes
-    - autogen-restricted-volumes
   - policyName: require-run-as-nonroot
     ruleNames:
-    - run-as-non-root 
+    - run-as-non-root
     - autogen-run-as-non-root
   - policyName: restrict-seccomp-strict
     ruleNames:
@@ -50,5 +42,5 @@ spec:
         namespaces:
         - kube-system
         names:
-        - azure-cloud-controller-manager*
+        - azure-cloud-node-manager*
 {{- end }}

--- a/helm/kyverno/values.schema.json
+++ b/helm/kyverno/values.schema.json
@@ -2029,6 +2029,9 @@
                 "enableAzureCloudControllerManagerPolex": {
                     "type": "boolean"
                 },
+                "enableAzureCloudNodeManagerPolex": {
+                    "type": "boolean"
+                },
                 "enableChartOperatorPolex": {
                     "type": "boolean"
                 },

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -82,6 +82,9 @@ policyExceptions:
   # Deploy a PolicyException for Azure Cloud Controller Manager (required for Giant Swarm clusters).
   enableAzureCloudControllerManagerPolex: true
 
+  # Deploy a PolicyException for Azure Cloud Node Manager (required for Giant Swarm clusters).
+  enableAzureCloudNodeManagerPolex: true
+
 # Upgrade job for Kyverno < 1.10.0 upgrades.
 upgradeJob:
   enabled: true


### PR DESCRIPTION
We have a circular dependency in CAPZ now. `azure-cloud-node-manager-app` depends on `kyverno` because of PolicyExceptions. `kyverno` depends on `chart-operator`, which depends on `Cilium` and `azure-cloud-node-manager-app` because of taints.  We decided to add core policies to kyverno app. See https://github.com/giantswarm/azure-cloud-node-manager-app/pull/46

Here is the discussion about where to add the exceptions.  https://gigantic.slack.com/archives/C02FL4EAADD/p1701181092993249?thread_ts=1696497100.521439&cid=C02FL4EAADD

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
