### PR TITLE
Add missing CiliumNetworkPolicies 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add missing `app.kubernetes.io/` labels to all the pods.
-- `CiliumNetworkPolicy` for:
+- Add `CiliumNetworkPolicy` for individual controllers:
   - `kyverno-admission-controller`
-  - `kyverno-plugin`
-  - `kyverno-policy-reporter`
   - `kyverno-background-controller`
   - `kyverno-reports-controller`
+  - `kyverno-cleanup-controller`
+  - `kyverno-cleanup-jobs`
+  - `kyverno-plugin`
+  - `kyverno-policy-reporter`
 
 ## [0.16.3] - 2023-11-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `CiliumNetworkPolicy` for:
+  - `kyverno-admission-controller`
+  - `kyverno-plugin`
+  - `kyverno-policy-reporter`
+  - `kyverno-background-controller`
+  - `kyverno-reports-controller`
+
 ## [0.16.3] - 2023-11-29
 
 ### Added

--- a/helm/kyverno/templates/kyverno-cilium/ciliumnetworkpolicy.yaml
+++ b/helm/kyverno/templates/kyverno-cilium/ciliumnetworkpolicy.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   endpointSelector:
     matchLabels:
+      # This would match only the pre-install and pre-upgrade jobs
       {{- include "kyverno-stack.selectorLabels" . | nindent 6 }}
   egress:
     - toEntities:
@@ -17,6 +18,26 @@ spec:
     - fromEntities:
         - kube-apiserver
         - cluster
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-kyverno-cleanup-jobs-talk-to-apiserver
+  namespace: {{ include "kyverno-stack.namespace" . }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: cleanup-jobs
+      app.kubernetes.io/instance: kyverno
+  egress:
+    - toEntities:
+      - kube-apiserver
+      toPorts:
+        - ports:
+          - port: "443"
+            protocol: TCP
+          - port: "6443"
+            protocol: TCP
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -87,6 +108,26 @@ spec:
   endpointSelector:
     matchLabels:
       app.kubernetes.io/component: background-controller
+      app.kubernetes.io/instance: kyverno
+  egress:
+    - toEntities:
+      - kube-apiserver
+      toPorts:
+        - ports:
+          - port: "443"
+            protocol: TCP
+          - port: "6443"
+            protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-kyverno-cleanup-controller-talk-to-apiserver
+  namespace: {{ include "kyverno-stack.namespace" . }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: cleanup-controller
       app.kubernetes.io/instance: kyverno
   egress:
     - toEntities:

--- a/helm/kyverno/templates/kyverno-cilium/ciliumnetworkpolicy.yaml
+++ b/helm/kyverno/templates/kyverno-cilium/ciliumnetworkpolicy.yaml
@@ -14,10 +14,21 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
+      toPorts:
+        - ports:
+          - port: "443"
+            protocol: TCP
+          - port: "6443"
+            protocol: TCP
   ingress:
     - fromEntities:
         - kube-apiserver
-        - cluster
+      toPorts:
+        - ports:
+          - port: "443"
+            protocol: TCP
+          - port: "6443"
+            protocol: TCP
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -136,6 +147,21 @@ spec:
             protocol: TCP
           - port: "6443"
             protocol: TCP
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+          - port: "443"
+            protocol: TCP
+          - port: "6443"
+            protocol: TCP
+    - fromEntities:
+        - cluster
+      toPorts:
+      - ports:
+        - port: "8000"
+          protocol: TCP
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -156,6 +182,21 @@ spec:
             protocol: TCP
           - port: "6443"
             protocol: TCP
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+          - port: "443"
+            protocol: TCP
+          - port: "6443"
+            protocol: TCP
+    - fromEntities:
+        - cluster
+      toPorts:
+      - ports:
+        - port: "8000"
+          protocol: TCP
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -176,4 +217,19 @@ spec:
             protocol: TCP
           - port: "6443"
             protocol: TCP
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+          - port: "443"
+            protocol: TCP
+          - port: "6443"
+            protocol: TCP
+    - fromEntities:
+        - cluster
+      toPorts:
+      - ports:
+        - port: "8000"
+          protocol: TCP
 {{- end }}

--- a/helm/kyverno/templates/kyverno-cilium/ciliumnetworkpolicy.yaml
+++ b/helm/kyverno/templates/kyverno-cilium/ciliumnetworkpolicy.yaml
@@ -2,7 +2,7 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  name: {{ template "kyverno-stack.fullname" . }}
+  name: allow-kyverno-install-jobs-talk-to-apiserver
   labels:
     {{- include "kyverno-stack.labels" . | nindent 4 }}
   namespace: {{ include "kyverno-stack.namespace" . }}

--- a/helm/kyverno/templates/kyverno-cilium/ciliumnetworkpolicy.yaml
+++ b/helm/kyverno/templates/kyverno-cilium/ciliumnetworkpolicy.yaml
@@ -17,4 +17,104 @@ spec:
     - fromEntities:
         - kube-apiserver
         - cluster
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-kyverno-admission-controller-talk-to-apiserver
+  namespace: {{ include "kyverno-stack.namespace" . }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: admission-controller
+      app.kubernetes.io/instance: kyverno
+  egress:
+    - toEntities:
+      - kube-apiserver
+      toPorts:
+        - ports:
+          - port: "443"
+            protocol: TCP
+          - port: "6443"
+            protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-kyverno-plugin-talk-to-apiserver
+  namespace: {{ include "kyverno-stack.namespace" . }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: kyverno-plugin
+      app.kubernetes.io/instance: kyverno
+  egress:
+    - toEntities:
+      - kube-apiserver
+      toPorts:
+        - ports:
+          - port: "443"
+            protocol: TCP
+          - port: "6443"
+            protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-kyverno-policy-reporter-talk-to-apiserver
+  namespace: {{ include "kyverno-stack.namespace" . }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: policy-reporter
+      app.kubernetes.io/instance: kyverno
+  egress:
+    - toEntities:
+      - kube-apiserver
+      toPorts:
+        - ports:
+          - port: "443"
+            protocol: TCP
+          - port: "6443"
+            protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-kyverno-background-controller-talk-to-apiserver
+  namespace: {{ include "kyverno-stack.namespace" . }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: background-controller
+      app.kubernetes.io/instance: kyverno
+  egress:
+    - toEntities:
+      - kube-apiserver
+      toPorts:
+        - ports:
+          - port: "443"
+            protocol: TCP
+          - port: "6443"
+            protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-kyverno-reports-controller-talk-to-apiserver
+  namespace: {{ include "kyverno-stack.namespace" . }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: reports-controller
+      app.kubernetes.io/instance: kyverno
+  egress:
+    - toEntities:
+      - kube-apiserver
+      toPorts:
+        - ports:
+          - port: "443"
+            protocol: TCP
+          - port: "6443"
+            protocol: TCP
 {{- end }}

--- a/helm/kyverno/templates/kyverno-cilium/ciliumnetworkpolicy.yaml
+++ b/helm/kyverno/templates/kyverno-cilium/ciliumnetworkpolicy.yaml
@@ -58,6 +58,22 @@ spec:
             protocol: TCP
           - port: "6443"
             protocol: TCP
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+        - remote-node
+      toPorts:
+        - ports:
+          - port: "443"
+            protocol: TCP
+          - port: "6443"
+            protocol: TCP
+    - fromEntities:
+        - cluster
+      toPorts:
+      - ports:
+        - port: "8000"
+          protocol: TCP
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/helm/kyverno/templates/kyverno-cilium/ciliumnetworkpolicy.yaml
+++ b/helm/kyverno/templates/kyverno-cilium/ciliumnetworkpolicy.yaml
@@ -68,6 +68,8 @@ spec:
             protocol: TCP
           - port: "6443"
             protocol: TCP
+          - port: "9443"
+            protocol: TCP
     - fromEntities:
         - cluster
       toPorts:

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -340,8 +340,8 @@ kyverno:
     replicas: 3
 
     # -- Additional labels to add to each pod
-    podLabels: {}
-      # example.com/label: foo
+    podLabels:
+      app.kubernetes.io/name: kyverno
 
     # -- Additional annotations to add to each pod
     podAnnotations: {}


### PR DESCRIPTION
for kyverno-admission-controller, kyverno-plugin, kyverno-policy-reporter, kyverno-background-controller and kyverno-reports-controller

Without them, the Kyverno doesn't work well in the locked environments. Example: https://tekton.ci.giantswarm.io/#/namespaces/mc-bootstrap/pipelineruns/pr-mc-bootstrap-729-generate-mc4zfmt?pipelineTask=generate-mc&step=generate-mc

I tested this here: https://github.com/giantswarm/mc-bootstrap/pull/729 I was creating them in the mc-bootstrap to workaround this issue, but they logically belong to the app itself.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
