### PR TITLE
Add missing component labels to all pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added missing `app.kubernetes.io/` labels to all the pods.
+
 ## [0.16.3] - 2023-11-29
 
 ### Added

--- a/helm/kyverno/templates/_helpers.tpl
+++ b/helm/kyverno/templates/_helpers.tpl
@@ -46,8 +46,8 @@ The longest name that gets created adds and extra 37 characters, so truncation s
 
 {{/* Generate basic labels */}}
 {{- define "kyverno-stack.labels" }}
+{{- include "kyverno-stack.selectorLabels" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: "{{ .Chart.Version }}"
 app.kubernetes.io/part-of: {{ template "kyverno-stack.name" . }}
 chart: {{ template "kyverno-stack.chartref" . }}

--- a/helm/kyverno/templates/crd-install/crd-job.yaml
+++ b/helm/kyverno/templates/crd-install/crd-job.yaml
@@ -10,8 +10,8 @@ metadata:
     {{- include "kyverno-stack.CRDInstallAnnotations" . | nindent 4 }}
   labels:
     app.kubernetes.io/component: {{ include "kyverno-stack.crdInstall" . | quote }}
-    {{- include "kyverno-stack.selectorLabels" . | nindent 4 }}
     role: {{ include "kyverno-stack.CRDInstallSelector" . | quote }}
+    {{- include "kyverno-stack.selectorLabels" . | nindent 4 }}
 spec:
   template:
     metadata:

--- a/helm/kyverno/templates/upgrade-job/upgrade-job.yaml
+++ b/helm/kyverno/templates/upgrade-job/upgrade-job.yaml
@@ -6,13 +6,17 @@ metadata:
   namespace: {{ template "kyverno-stack.namespace" . }}
   labels:
     app.kubernetes.io/component: {{ include "kyverno-stack.upgradeJob.name" . | quote }}
-    {{- include "kyverno-stack.labels" . | nindent 4 }}
+    {{- include "kyverno-stack.selectorLabels" . | nindent 4 }}
   annotations:
     "helm.sh/hook-weight": "-2"
     {{- include "kyverno-stack.upgradeJob.annotations" . | nindent 4 }}
 spec:
   backoffLimit: 2
   template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: {{ include "kyverno-stack.upgradeJob.name" . | quote }}
+        {{- include "kyverno-stack.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: Never
       serviceAccountName: {{ include "kyverno-stack.upgradeJob.name" . }}

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -245,6 +245,11 @@ kyverno:
         seccompProfile:
           type: RuntimeDefault
 
+      # -- Labels for the CleanupJob
+      podLabels:
+        app.kubernetes.io/component: cleanup-jobs
+        app.kubernetes.io/instance: kyverno
+
     clusterAdmissionReports:
 
       # -- Enable cleanup cronjob
@@ -291,6 +296,11 @@ kyverno:
             - ALL
         seccompProfile:
           type: RuntimeDefault
+
+      # -- Labels for the CleanupJob
+      podLabels:
+        app.kubernetes.io/component: cleanup-jobs
+        app.kubernetes.io/instance: kyverno
 
   # Admission controller configuration
   admissionController:

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -1121,6 +1121,8 @@ kyverno:
 
 # Additional options defined in charts/policy-reporter/values.yaml. Upstream docs: https://github.com/kyverno/policy-reporter
 policy-reporter:
+  podLabels:
+    app.kubernetes.io/component: policy-reporter
   image:
     registry: docker.io
     repository: giantswarm/policy-reporter
@@ -1136,6 +1138,8 @@ policy-reporter:
 
   ui:
     enabled: true
+    podLabels:
+      app.kubernetes.io/component: ui
     image:
       registry: docker.io
       repository: giantswarm/policy-reporter-ui
@@ -1155,6 +1159,8 @@ policy-reporter:
   kyvernoPlugin:
     enabled: true
     annotations: {}
+    podLabels:
+      app.kubernetes.io/component: plugin
     image:
       registry: docker.io
       repository: giantswarm/policy-reporter-kyverno-plugin


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/29184

This PR adds the missing labels to all the pods.

We will fix the CiliumNetworkPolicies in another pr.
