### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [0.16.4] - 2023-12-06
 
 ### Added

--- a/helm/kyverno/charts/kyverno/values.yaml
+++ b/helm/kyverno/charts/kyverno/values.yaml
@@ -3,16 +3,16 @@
 templating:
   enabled: false
   debug: false
-  version: ~
+  version:
 
 # -- (string) Override the name of the chart
-nameOverride: ~
+nameOverride:
 
 # -- (string) Override the expanded name of the chart
-fullnameOverride: ~
+fullnameOverride:
 
 # -- (string) Override the namespace the chart deploys to
-namespaceOverride: ~
+namespaceOverride:
 
 upgrade:
   # -- Upgrading from v2 to v3 is not allowed by default, set this to true once changes have been reviewed.
@@ -22,7 +22,7 @@ apiVersionOverride:
   # -- (string) Override api version used to create `PodDisruptionBudget`` resources.
   # When not specified the chart will check if `policy/v1/PodDisruptionBudget` is available to
   # determine the api version automatically.
-  podDisruptionBudget: ~
+  podDisruptionBudget:
 
 # CRDs configuration
 crds:
@@ -42,7 +42,7 @@ config:
   create: true
 
   # -- (string) The configmap name (required if `create` is `false`).
-  name: ~
+  name:
 
   # -- Additional annotations to add to the configmap.
   annotations: {}
@@ -51,7 +51,7 @@ config:
   enableDefaultRegistryMutation: true
 
   # -- The registry hostname used for the image mutation.
-  defaultRegistry: docker.io
+  defaultRegistry: gsoci.azurecr.io
 
   # -- Exclude groups
   excludeGroups:
@@ -111,80 +111,159 @@ config:
     - '[ClusterRole,*,{{ template "kyverno.reports-controller.roleName" . }}]'
     - '[ClusterRole,*,{{ template "kyverno.reports-controller.roleName" . }}:core]'
     - '[ClusterRole,*,{{ template "kyverno.reports-controller.roleName" . }}:additional]'
-    - '[ClusterRoleBinding,*,{{ template "kyverno.admission-controller.roleName" . }}]'
-    - '[ClusterRoleBinding,*,{{ template "kyverno.background-controller.roleName" . }}]'
+    - '[ClusterRoleBinding,*,{{ template "kyverno.admission-controller.roleName" .
+      }}]'
+    - '[ClusterRoleBinding,*,{{ template "kyverno.background-controller.roleName"
+      . }}]'
     - '[ClusterRoleBinding,*,{{ template "kyverno.cleanup-controller.roleName" . }}]'
     - '[ClusterRoleBinding,*,{{ template "kyverno.reports-controller.roleName" . }}]'
-    - '[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceAccountName" . }}]'
-    - '[ServiceAccount/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceAccountName" . }}]'
-    - '[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.serviceAccountName" . }}]'
-    - '[ServiceAccount/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.serviceAccountName" . }}]'
-    - '[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.serviceAccountName" . }}]'
-    - '[ServiceAccount/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.serviceAccountName" . }}]'
-    - '[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.serviceAccountName" . }}]'
-    - '[ServiceAccount/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.serviceAccountName" . }}]'
-    - '[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.roleName" . }}]'
-    - '[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.roleName" . }}]'
-    - '[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.roleName" . }}]'
-    - '[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.roleName" . }}]'
-    - '[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.roleName" . }}]'
-    - '[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.roleName" . }}]'
-    - '[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.roleName" . }}]'
-    - '[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.roleName" . }}]'
-    - '[ConfigMap,{{ include "kyverno.namespace" . }},{{ template "kyverno.config.configMapName" . }}]'
-    - '[ConfigMap,{{ include "kyverno.namespace" . }},{{ template "kyverno.config.metricsConfigMapName" . }}]'
-    - '[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}]'
-    - '[Deployment/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}]'
-    - '[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}]'
-    - '[Deployment/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}]'
-    - '[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]'
-    - '[Deployment/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]'
-    - '[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}]'
-    - '[Deployment/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}]'
-    - '[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}-*]'
-    - '[Pod/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}-*]'
-    - '[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}-*]'
-    - '[Pod/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}-*]'
-    - '[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}-*]'
-    - '[Pod/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}-*]'
-    - '[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}-*]'
-    - '[Pod/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}-*]'
+    - '[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceAccountName"
+      . }}]'
+    - '[ServiceAccount/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceAccountName"
+      . }}]'
+    - '[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.serviceAccountName"
+      . }}]'
+    - '[ServiceAccount/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.serviceAccountName"
+      . }}]'
+    - '[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.serviceAccountName"
+      . }}]'
+    - '[ServiceAccount/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.serviceAccountName"
+      . }}]'
+    - '[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.serviceAccountName"
+      . }}]'
+    - '[ServiceAccount/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.serviceAccountName"
+      . }}]'
+    - '[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.roleName"
+      . }}]'
+    - '[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.roleName"
+      . }}]'
+    - '[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.roleName"
+      . }}]'
+    - '[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.roleName"
+      . }}]'
+    - '[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.roleName"
+      . }}]'
+    - '[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.roleName"
+      . }}]'
+    - '[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.roleName"
+      . }}]'
+    - '[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.roleName"
+      . }}]'
+    - '[ConfigMap,{{ include "kyverno.namespace" . }},{{ template "kyverno.config.configMapName"
+      . }}]'
+    - '[ConfigMap,{{ include "kyverno.namespace" . }},{{ template "kyverno.config.metricsConfigMapName"
+      . }}]'
+    - '[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name"
+      . }}]'
+    - '[Deployment/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name"
+      . }}]'
+    - '[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name"
+      . }}]'
+    - '[Deployment/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name"
+      . }}]'
+    - '[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
+      . }}]'
+    - '[Deployment/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
+      . }}]'
+    - '[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name"
+      . }}]'
+    - '[Deployment/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name"
+      . }}]'
+    - '[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name"
+      . }}-*]'
+    - '[Pod/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name"
+      . }}-*]'
+    - '[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name"
+      . }}-*]'
+    - '[Pod/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name"
+      . }}-*]'
+    - '[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
+      . }}-*]'
+    - '[Pod/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
+      . }}-*]'
+    - '[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name"
+      . }}-*]'
+    - '[Pod/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name"
+      . }}-*]'
     - '[Job,{{ include "kyverno.namespace" . }},{{ template "kyverno.fullname" . }}-hook-pre-delete]'
-    - '[Job/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.fullname" . }}-hook-pre-delete]'
-    - '[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}]'
-    - '[NetworkPolicy/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}]'
-    - '[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}]'
-    - '[NetworkPolicy/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}]'
-    - '[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]'
-    - '[NetworkPolicy/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]'
-    - '[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}]'
-    - '[NetworkPolicy/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}]'
-    - '[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}]'
-    - '[PodDisruptionBudget/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}]'
-    - '[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}]'
-    - '[PodDisruptionBudget/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}]'
-    - '[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]'
-    - '[PodDisruptionBudget/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]'
-    - '[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}]'
-    - '[PodDisruptionBudget/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}]'
-    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName" . }}]'
-    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName" . }}]'
-    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName" . }}-metrics]'
-    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName" . }}-metrics]'
-    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}-metrics]'
-    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}-metrics]'
-    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]'
-    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]'
-    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}-metrics]'
-    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}-metrics]'
-    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}-metrics]'
-    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}-metrics]'
-    - '[ServiceMonitor,{{ if .Values.admissionController.serviceMonitor.namespace }}{{ .Values.admissionController.serviceMonitor.namespace }}{{ else }}{{ template "kyverno.namespace" . }}{{ end }},{{ template "kyverno.admission-controller.name" . }}]'
-    - '[ServiceMonitor,{{ if .Values.admissionController.serviceMonitor.namespace }}{{ .Values.admissionController.serviceMonitor.namespace }}{{ else }}{{ template "kyverno.namespace" . }}{{ end }},{{ template "kyverno.background-controller.name" . }}]'
-    - '[ServiceMonitor,{{ if .Values.admissionController.serviceMonitor.namespace }}{{ .Values.admissionController.serviceMonitor.namespace }}{{ else }}{{ template "kyverno.namespace" . }}{{ end }},{{ template "kyverno.cleanup-controller.name" . }}]'
-    - '[ServiceMonitor,{{ if .Values.admissionController.serviceMonitor.namespace }}{{ .Values.admissionController.serviceMonitor.namespace }}{{ else }}{{ template "kyverno.namespace" . }}{{ end }},{{ template "kyverno.reports-controller.name" . }}]'
-    - '[Secret,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName" . }}.{{ template "kyverno.namespace" . }}.svc.*]'
-    - '[Secret,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}.{{ template "kyverno.namespace" . }}.svc.*]'
+    - '[Job/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.fullname" .
+      }}-hook-pre-delete]'
+    - '[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name"
+      . }}]'
+    - '[NetworkPolicy/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name"
+      . }}]'
+    - '[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name"
+      . }}]'
+    - '[NetworkPolicy/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name"
+      . }}]'
+    - '[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
+      . }}]'
+    - '[NetworkPolicy/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
+      . }}]'
+    - '[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name"
+      . }}]'
+    - '[NetworkPolicy/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name"
+      . }}]'
+    - '[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name"
+      . }}]'
+    - '[PodDisruptionBudget/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name"
+      . }}]'
+    - '[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name"
+      . }}]'
+    - '[PodDisruptionBudget/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name"
+      . }}]'
+    - '[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
+      . }}]'
+    - '[PodDisruptionBudget/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
+      . }}]'
+    - '[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name"
+      . }}]'
+    - '[PodDisruptionBudget/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name"
+      . }}]'
+    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName"
+      . }}]'
+    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName"
+      . }}]'
+    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName"
+      . }}-metrics]'
+    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName"
+      . }}-metrics]'
+    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name"
+      . }}-metrics]'
+    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name"
+      . }}-metrics]'
+    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
+      . }}]'
+    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
+      . }}]'
+    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
+      . }}-metrics]'
+    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
+      . }}-metrics]'
+    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name"
+      . }}-metrics]'
+    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name"
+      . }}-metrics]'
+    - '[ServiceMonitor,{{ if .Values.admissionController.serviceMonitor.namespace
+      }}{{ .Values.admissionController.serviceMonitor.namespace }}{{ else }}{{ template
+      "kyverno.namespace" . }}{{ end }},{{ template "kyverno.admission-controller.name"
+      . }}]'
+    - '[ServiceMonitor,{{ if .Values.admissionController.serviceMonitor.namespace
+      }}{{ .Values.admissionController.serviceMonitor.namespace }}{{ else }}{{ template
+      "kyverno.namespace" . }}{{ end }},{{ template "kyverno.background-controller.name"
+      . }}]'
+    - '[ServiceMonitor,{{ if .Values.admissionController.serviceMonitor.namespace
+      }}{{ .Values.admissionController.serviceMonitor.namespace }}{{ else }}{{ template
+      "kyverno.namespace" . }}{{ end }},{{ template "kyverno.cleanup-controller.name"
+      . }}]'
+    - '[ServiceMonitor,{{ if .Values.admissionController.serviceMonitor.namespace
+      }}{{ .Values.admissionController.serviceMonitor.namespace }}{{ else }}{{ template
+      "kyverno.namespace" . }}{{ end }},{{ template "kyverno.reports-controller.name"
+      . }}]'
+    - '[Secret,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName"
+      . }}.{{ template "kyverno.namespace" . }}.svc.*]'
+    - '[Secret,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
+      . }}.{{ template "kyverno.namespace" . }}.svc.*]'
     - '[*,giantswarm,chart-operator*]'
 
   # -- Defines the `namespaceSelector` in the webhook configurations.
@@ -226,7 +305,7 @@ metricsConfig:
   create: true
 
   # -- (string) The configmap name (required if `create` is `false`).
-  name: ~
+  name:
 
   # -- Additional annotations to add to the configmap.
   annotations: {}
@@ -240,7 +319,7 @@ metricsConfig:
     exclude: []
 
   # -- (string) Rate at which metrics should reset so as to clean up the memory footprint of kyverno metrics, if you might be expecting high memory footprint of Kyverno's metrics. Default: 0, no refresh of metrics
-  metricsRefreshInterval: ~
+  metricsRefreshInterval:
     # metricsRefreshInterval: 24h
 
 # -- Image pull secrets for image verification policies, this will define the `--imagePullSecrets` argument
@@ -264,7 +343,7 @@ test:
 
   image:
     # -- (string) Image registry
-    registry: ~
+    registry:
     # -- Image repository
     repository: busybox
     # -- Image tag
@@ -272,7 +351,7 @@ test:
     tag: '1.35'
     # -- (string) Image pull policy
     # Defaults to image.pullPolicy if omitted
-    pullPolicy: ~
+    pullPolicy:
 
   resources:
     # -- Pod resource limits
@@ -318,7 +397,7 @@ grafana:
 
   # -- (string) Namespace to create the grafana dashboard configmap.
   # If not set, it will be created in the same namespace where the chart is deployed.
-  namespace: ~
+  namespace:
 
   # -- Grafana dashboard configmap annotations.
   annotations: {}
@@ -381,11 +460,11 @@ features:
     allowInsecure: false
     # -- Enable registry client helpers
     credentialHelpers:
-    - default
-    - google
-    - amazon
-    - azure
-    - github
+      - default
+      - google
+      - amazon
+      - azure
+      - github
   reports:
     # -- Reports chunk size
     chunkSize: 1000
@@ -400,7 +479,7 @@ cleanupJobs:
 
     image:
       # -- (string) Image registry
-      registry: ~
+      registry:
       # -- Image repository
       repository: bitnami/kubectl
       # -- Image tag
@@ -408,7 +487,7 @@ cleanupJobs:
       tag: '1.26.4'
       # -- (string) Image pull policy
       # Defaults to image.pullPolicy if omitted
-      pullPolicy: ~
+      pullPolicy:
 
     # -- Image pull secrets
     imagePullSecrets: []
@@ -456,7 +535,7 @@ cleanupJobs:
 
     image:
       # -- (string) Image registry
-      registry: ~
+      registry:
       # -- Image repository
       repository: bitnami/kubectl
       # -- Image tag
@@ -464,7 +543,7 @@ cleanupJobs:
       tag: '1.26.4'
       # -- (string) Image pull policy
       # Defaults to image.pullPolicy if omitted
-      pullPolicy: ~
+      pullPolicy:
 
     # -- Image pull secrets
     imagePullSecrets: []
@@ -540,7 +619,7 @@ admissionController:
   createSelfSignedCert: false
 
   # -- (int) Desired number of pods
-  replicas: ~
+  replicas:
 
   # -- Additional labels to add to each pod
   podLabels: {}
@@ -680,10 +759,10 @@ admissionController:
       repository: kyverno/kyvernopre
       # -- (string) Image tag
       # If missing, defaults to image.tag
-      tag: ~
+      tag:
       # -- (string) Image pull policy
       # If missing, defaults to image.pullPolicy
-      pullPolicy: ~
+      pullPolicy:
 
     resources:
       # -- Pod resource limits
@@ -722,7 +801,7 @@ admissionController:
       repository: kyverno/kyverno
       # -- (string) Image tag
       # Defaults to appVersion in Chart.yaml if omitted
-      tag: ~
+      tag:
       # -- Image pull policy
       pullPolicy: IfNotPresent
 
@@ -803,7 +882,7 @@ admissionController:
     # -- Additional labels
     additionalLabels: {}
     # -- (string) Override namespace
-    namespace: ~
+    namespace:
     # --  Interval to scrape metrics
     interval: 30s
     # -- Timeout if metrics can't be retrieved in given time interval
@@ -889,7 +968,7 @@ backgroundController:
     # - secretName
 
   # -- (int) Desired number of pods
-  replicas: ~
+  replicas:
 
   # -- Additional labels to add to each pod
   podLabels: {}
@@ -1022,7 +1101,7 @@ backgroundController:
     # -- Additional labels
     additionalLabels: {}
     # -- (string) Override namespace
-    namespace: ~
+    namespace:
     # --  Interval to scrape metrics
     interval: 30s
     # -- Timeout if metrics can't be retrieved in given time interval
@@ -1098,7 +1177,7 @@ cleanupController:
     repository: kyverno/cleanup-controller
     # -- (string) Image tag
     # Defaults to appVersion in Chart.yaml if omitted
-    tag: ~
+    tag:
     # -- Image pull policy
     pullPolicy: IfNotPresent
 
@@ -1107,7 +1186,7 @@ cleanupController:
     # - secretName
 
   # -- (int) Desired number of pods
-  replicas: ~
+  replicas:
 
   # -- Additional labels to add to each pod
   podLabels: {}
@@ -1294,7 +1373,7 @@ cleanupController:
     # -- Additional labels
     additionalLabels: {}
     # -- (string) Override namespace
-    namespace: ~
+    namespace:
     # --  Interval to scrape metrics
     interval: 30s
     # -- Timeout if metrics can't be retrieved in given time interval
@@ -1366,7 +1445,7 @@ reportsController:
     repository: kyverno/reports-controller
     # -- (string) Image tag
     # Defaults to appVersion in Chart.yaml if omitted
-    tag: ~
+    tag:
     # -- Image pull policy
     pullPolicy: IfNotPresent
 
@@ -1375,7 +1454,7 @@ reportsController:
     # - secretName
 
   # -- (int) Desired number of pods
-  replicas: ~
+  replicas:
 
   # -- Additional labels to add to each pod
   podLabels: {}
@@ -1496,7 +1575,7 @@ reportsController:
     type: ClusterIP
     # -- (string) Service node port.
     # Only used if `type` is `NodePort`.
-    nodePort: ~
+    nodePort:
     # -- Service annotations.
     annotations: {}
 
@@ -1515,7 +1594,7 @@ reportsController:
     # -- Additional labels
     additionalLabels: {}
     # -- (string) Override namespace
-    namespace: ~
+    namespace:
     # -- Interval to scrape metrics
     interval: 30s
     # -- Timeout if metrics can't be retrieved in given time interval
@@ -1533,11 +1612,11 @@ reportsController:
     # -- Enable tracing
     enabled: false
     # -- (string) Traces receiver address
-    address: ~
+    address:
     # -- (string) Traces receiver port
-    port: ~
+    port:
     # -- (string) Traces receiver credentials
-    creds: ~
+    creds:
 
   metering:
     # -- Disable metrics export
@@ -1547,6 +1626,6 @@ reportsController:
     # -- Prometheus endpoint port
     port: 8000
     # -- (string) Otel collector endpoint
-    collector: ~
+    collector:
     # -- (string) Otel collector credentials
-    creds: ~
+    creds:

--- a/helm/kyverno/charts/kyverno/values.yaml
+++ b/helm/kyverno/charts/kyverno/values.yaml
@@ -3,16 +3,16 @@
 templating:
   enabled: false
   debug: false
-  version:
+  version: ~
 
 # -- (string) Override the name of the chart
-nameOverride:
+nameOverride: ~
 
 # -- (string) Override the expanded name of the chart
-fullnameOverride:
+fullnameOverride: ~
 
 # -- (string) Override the namespace the chart deploys to
-namespaceOverride:
+namespaceOverride: ~
 
 upgrade:
   # -- Upgrading from v2 to v3 is not allowed by default, set this to true once changes have been reviewed.
@@ -22,7 +22,7 @@ apiVersionOverride:
   # -- (string) Override api version used to create `PodDisruptionBudget`` resources.
   # When not specified the chart will check if `policy/v1/PodDisruptionBudget` is available to
   # determine the api version automatically.
-  podDisruptionBudget:
+  podDisruptionBudget: ~
 
 # CRDs configuration
 crds:
@@ -42,7 +42,7 @@ config:
   create: true
 
   # -- (string) The configmap name (required if `create` is `false`).
-  name:
+  name: ~
 
   # -- Additional annotations to add to the configmap.
   annotations: {}
@@ -111,159 +111,80 @@ config:
     - '[ClusterRole,*,{{ template "kyverno.reports-controller.roleName" . }}]'
     - '[ClusterRole,*,{{ template "kyverno.reports-controller.roleName" . }}:core]'
     - '[ClusterRole,*,{{ template "kyverno.reports-controller.roleName" . }}:additional]'
-    - '[ClusterRoleBinding,*,{{ template "kyverno.admission-controller.roleName" .
-      }}]'
-    - '[ClusterRoleBinding,*,{{ template "kyverno.background-controller.roleName"
-      . }}]'
+    - '[ClusterRoleBinding,*,{{ template "kyverno.admission-controller.roleName" . }}]'
+    - '[ClusterRoleBinding,*,{{ template "kyverno.background-controller.roleName" . }}]'
     - '[ClusterRoleBinding,*,{{ template "kyverno.cleanup-controller.roleName" . }}]'
     - '[ClusterRoleBinding,*,{{ template "kyverno.reports-controller.roleName" . }}]'
-    - '[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceAccountName"
-      . }}]'
-    - '[ServiceAccount/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceAccountName"
-      . }}]'
-    - '[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.serviceAccountName"
-      . }}]'
-    - '[ServiceAccount/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.serviceAccountName"
-      . }}]'
-    - '[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.serviceAccountName"
-      . }}]'
-    - '[ServiceAccount/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.serviceAccountName"
-      . }}]'
-    - '[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.serviceAccountName"
-      . }}]'
-    - '[ServiceAccount/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.serviceAccountName"
-      . }}]'
-    - '[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.roleName"
-      . }}]'
-    - '[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.roleName"
-      . }}]'
-    - '[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.roleName"
-      . }}]'
-    - '[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.roleName"
-      . }}]'
-    - '[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.roleName"
-      . }}]'
-    - '[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.roleName"
-      . }}]'
-    - '[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.roleName"
-      . }}]'
-    - '[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.roleName"
-      . }}]'
-    - '[ConfigMap,{{ include "kyverno.namespace" . }},{{ template "kyverno.config.configMapName"
-      . }}]'
-    - '[ConfigMap,{{ include "kyverno.namespace" . }},{{ template "kyverno.config.metricsConfigMapName"
-      . }}]'
-    - '[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name"
-      . }}]'
-    - '[Deployment/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name"
-      . }}]'
-    - '[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name"
-      . }}]'
-    - '[Deployment/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name"
-      . }}]'
-    - '[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
-      . }}]'
-    - '[Deployment/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
-      . }}]'
-    - '[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name"
-      . }}]'
-    - '[Deployment/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name"
-      . }}]'
-    - '[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name"
-      . }}-*]'
-    - '[Pod/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name"
-      . }}-*]'
-    - '[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name"
-      . }}-*]'
-    - '[Pod/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name"
-      . }}-*]'
-    - '[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
-      . }}-*]'
-    - '[Pod/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
-      . }}-*]'
-    - '[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name"
-      . }}-*]'
-    - '[Pod/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name"
-      . }}-*]'
+    - '[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceAccountName" . }}]'
+    - '[ServiceAccount/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceAccountName" . }}]'
+    - '[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.serviceAccountName" . }}]'
+    - '[ServiceAccount/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.serviceAccountName" . }}]'
+    - '[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.serviceAccountName" . }}]'
+    - '[ServiceAccount/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.serviceAccountName" . }}]'
+    - '[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.serviceAccountName" . }}]'
+    - '[ServiceAccount/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.serviceAccountName" . }}]'
+    - '[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.roleName" . }}]'
+    - '[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.roleName" . }}]'
+    - '[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.roleName" . }}]'
+    - '[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.roleName" . }}]'
+    - '[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.roleName" . }}]'
+    - '[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.roleName" . }}]'
+    - '[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.roleName" . }}]'
+    - '[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.roleName" . }}]'
+    - '[ConfigMap,{{ include "kyverno.namespace" . }},{{ template "kyverno.config.configMapName" . }}]'
+    - '[ConfigMap,{{ include "kyverno.namespace" . }},{{ template "kyverno.config.metricsConfigMapName" . }}]'
+    - '[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}]'
+    - '[Deployment/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}]'
+    - '[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}]'
+    - '[Deployment/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}]'
+    - '[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]'
+    - '[Deployment/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]'
+    - '[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}]'
+    - '[Deployment/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}]'
+    - '[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}-*]'
+    - '[Pod/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}-*]'
+    - '[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}-*]'
+    - '[Pod/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}-*]'
+    - '[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}-*]'
+    - '[Pod/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}-*]'
+    - '[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}-*]'
+    - '[Pod/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}-*]'
     - '[Job,{{ include "kyverno.namespace" . }},{{ template "kyverno.fullname" . }}-hook-pre-delete]'
-    - '[Job/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.fullname" .
-      }}-hook-pre-delete]'
-    - '[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name"
-      . }}]'
-    - '[NetworkPolicy/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name"
-      . }}]'
-    - '[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name"
-      . }}]'
-    - '[NetworkPolicy/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name"
-      . }}]'
-    - '[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
-      . }}]'
-    - '[NetworkPolicy/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
-      . }}]'
-    - '[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name"
-      . }}]'
-    - '[NetworkPolicy/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name"
-      . }}]'
-    - '[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name"
-      . }}]'
-    - '[PodDisruptionBudget/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name"
-      . }}]'
-    - '[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name"
-      . }}]'
-    - '[PodDisruptionBudget/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name"
-      . }}]'
-    - '[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
-      . }}]'
-    - '[PodDisruptionBudget/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
-      . }}]'
-    - '[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name"
-      . }}]'
-    - '[PodDisruptionBudget/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name"
-      . }}]'
-    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName"
-      . }}]'
-    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName"
-      . }}]'
-    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName"
-      . }}-metrics]'
-    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName"
-      . }}-metrics]'
-    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name"
-      . }}-metrics]'
-    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name"
-      . }}-metrics]'
-    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
-      . }}]'
-    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
-      . }}]'
-    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
-      . }}-metrics]'
-    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
-      . }}-metrics]'
-    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name"
-      . }}-metrics]'
-    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name"
-      . }}-metrics]'
-    - '[ServiceMonitor,{{ if .Values.admissionController.serviceMonitor.namespace
-      }}{{ .Values.admissionController.serviceMonitor.namespace }}{{ else }}{{ template
-      "kyverno.namespace" . }}{{ end }},{{ template "kyverno.admission-controller.name"
-      . }}]'
-    - '[ServiceMonitor,{{ if .Values.admissionController.serviceMonitor.namespace
-      }}{{ .Values.admissionController.serviceMonitor.namespace }}{{ else }}{{ template
-      "kyverno.namespace" . }}{{ end }},{{ template "kyverno.background-controller.name"
-      . }}]'
-    - '[ServiceMonitor,{{ if .Values.admissionController.serviceMonitor.namespace
-      }}{{ .Values.admissionController.serviceMonitor.namespace }}{{ else }}{{ template
-      "kyverno.namespace" . }}{{ end }},{{ template "kyverno.cleanup-controller.name"
-      . }}]'
-    - '[ServiceMonitor,{{ if .Values.admissionController.serviceMonitor.namespace
-      }}{{ .Values.admissionController.serviceMonitor.namespace }}{{ else }}{{ template
-      "kyverno.namespace" . }}{{ end }},{{ template "kyverno.reports-controller.name"
-      . }}]'
-    - '[Secret,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName"
-      . }}.{{ template "kyverno.namespace" . }}.svc.*]'
-    - '[Secret,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name"
-      . }}.{{ template "kyverno.namespace" . }}.svc.*]'
+    - '[Job/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.fullname" . }}-hook-pre-delete]'
+    - '[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}]'
+    - '[NetworkPolicy/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}]'
+    - '[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}]'
+    - '[NetworkPolicy/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}]'
+    - '[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]'
+    - '[NetworkPolicy/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]'
+    - '[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}]'
+    - '[NetworkPolicy/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}]'
+    - '[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}]'
+    - '[PodDisruptionBudget/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}]'
+    - '[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}]'
+    - '[PodDisruptionBudget/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}]'
+    - '[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]'
+    - '[PodDisruptionBudget/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]'
+    - '[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}]'
+    - '[PodDisruptionBudget/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}]'
+    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName" . }}]'
+    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName" . }}]'
+    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName" . }}-metrics]'
+    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName" . }}-metrics]'
+    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}-metrics]'
+    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}-metrics]'
+    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]'
+    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]'
+    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}-metrics]'
+    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}-metrics]'
+    - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}-metrics]'
+    - '[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}-metrics]'
+    - '[ServiceMonitor,{{ if .Values.admissionController.serviceMonitor.namespace }}{{ .Values.admissionController.serviceMonitor.namespace }}{{ else }}{{ template "kyverno.namespace" . }}{{ end }},{{ template "kyverno.admission-controller.name" . }}]'
+    - '[ServiceMonitor,{{ if .Values.admissionController.serviceMonitor.namespace }}{{ .Values.admissionController.serviceMonitor.namespace }}{{ else }}{{ template "kyverno.namespace" . }}{{ end }},{{ template "kyverno.background-controller.name" . }}]'
+    - '[ServiceMonitor,{{ if .Values.admissionController.serviceMonitor.namespace }}{{ .Values.admissionController.serviceMonitor.namespace }}{{ else }}{{ template "kyverno.namespace" . }}{{ end }},{{ template "kyverno.cleanup-controller.name" . }}]'
+    - '[ServiceMonitor,{{ if .Values.admissionController.serviceMonitor.namespace }}{{ .Values.admissionController.serviceMonitor.namespace }}{{ else }}{{ template "kyverno.namespace" . }}{{ end }},{{ template "kyverno.reports-controller.name" . }}]'
+    - '[Secret,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName" . }}.{{ template "kyverno.namespace" . }}.svc.*]'
+    - '[Secret,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}.{{ template "kyverno.namespace" . }}.svc.*]'
     - '[*,giantswarm,chart-operator*]'
 
   # -- Defines the `namespaceSelector` in the webhook configurations.
@@ -305,7 +226,7 @@ metricsConfig:
   create: true
 
   # -- (string) The configmap name (required if `create` is `false`).
-  name:
+  name: ~
 
   # -- Additional annotations to add to the configmap.
   annotations: {}
@@ -319,7 +240,7 @@ metricsConfig:
     exclude: []
 
   # -- (string) Rate at which metrics should reset so as to clean up the memory footprint of kyverno metrics, if you might be expecting high memory footprint of Kyverno's metrics. Default: 0, no refresh of metrics
-  metricsRefreshInterval:
+  metricsRefreshInterval: ~
     # metricsRefreshInterval: 24h
 
 # -- Image pull secrets for image verification policies, this will define the `--imagePullSecrets` argument
@@ -343,7 +264,7 @@ test:
 
   image:
     # -- (string) Image registry
-    registry:
+    registry: ~
     # -- Image repository
     repository: busybox
     # -- Image tag
@@ -351,7 +272,7 @@ test:
     tag: '1.35'
     # -- (string) Image pull policy
     # Defaults to image.pullPolicy if omitted
-    pullPolicy:
+    pullPolicy: ~
 
   resources:
     # -- Pod resource limits
@@ -397,7 +318,7 @@ grafana:
 
   # -- (string) Namespace to create the grafana dashboard configmap.
   # If not set, it will be created in the same namespace where the chart is deployed.
-  namespace:
+  namespace: ~
 
   # -- Grafana dashboard configmap annotations.
   annotations: {}
@@ -460,11 +381,11 @@ features:
     allowInsecure: false
     # -- Enable registry client helpers
     credentialHelpers:
-      - default
-      - google
-      - amazon
-      - azure
-      - github
+    - default
+    - google
+    - amazon
+    - azure
+    - github
   reports:
     # -- Reports chunk size
     chunkSize: 1000
@@ -479,7 +400,7 @@ cleanupJobs:
 
     image:
       # -- (string) Image registry
-      registry:
+      registry: ~
       # -- Image repository
       repository: bitnami/kubectl
       # -- Image tag
@@ -487,7 +408,7 @@ cleanupJobs:
       tag: '1.26.4'
       # -- (string) Image pull policy
       # Defaults to image.pullPolicy if omitted
-      pullPolicy:
+      pullPolicy: ~
 
     # -- Image pull secrets
     imagePullSecrets: []
@@ -535,7 +456,7 @@ cleanupJobs:
 
     image:
       # -- (string) Image registry
-      registry:
+      registry: ~
       # -- Image repository
       repository: bitnami/kubectl
       # -- Image tag
@@ -543,7 +464,7 @@ cleanupJobs:
       tag: '1.26.4'
       # -- (string) Image pull policy
       # Defaults to image.pullPolicy if omitted
-      pullPolicy:
+      pullPolicy: ~
 
     # -- Image pull secrets
     imagePullSecrets: []
@@ -619,7 +540,7 @@ admissionController:
   createSelfSignedCert: false
 
   # -- (int) Desired number of pods
-  replicas:
+  replicas: ~
 
   # -- Additional labels to add to each pod
   podLabels: {}
@@ -759,10 +680,10 @@ admissionController:
       repository: kyverno/kyvernopre
       # -- (string) Image tag
       # If missing, defaults to image.tag
-      tag:
+      tag: ~
       # -- (string) Image pull policy
       # If missing, defaults to image.pullPolicy
-      pullPolicy:
+      pullPolicy: ~
 
     resources:
       # -- Pod resource limits
@@ -801,7 +722,7 @@ admissionController:
       repository: kyverno/kyverno
       # -- (string) Image tag
       # Defaults to appVersion in Chart.yaml if omitted
-      tag:
+      tag: ~
       # -- Image pull policy
       pullPolicy: IfNotPresent
 
@@ -882,7 +803,7 @@ admissionController:
     # -- Additional labels
     additionalLabels: {}
     # -- (string) Override namespace
-    namespace:
+    namespace: ~
     # --  Interval to scrape metrics
     interval: 30s
     # -- Timeout if metrics can't be retrieved in given time interval
@@ -968,7 +889,7 @@ backgroundController:
     # - secretName
 
   # -- (int) Desired number of pods
-  replicas:
+  replicas: ~
 
   # -- Additional labels to add to each pod
   podLabels: {}
@@ -1101,7 +1022,7 @@ backgroundController:
     # -- Additional labels
     additionalLabels: {}
     # -- (string) Override namespace
-    namespace:
+    namespace: ~
     # --  Interval to scrape metrics
     interval: 30s
     # -- Timeout if metrics can't be retrieved in given time interval
@@ -1177,7 +1098,7 @@ cleanupController:
     repository: kyverno/cleanup-controller
     # -- (string) Image tag
     # Defaults to appVersion in Chart.yaml if omitted
-    tag:
+    tag: ~
     # -- Image pull policy
     pullPolicy: IfNotPresent
 
@@ -1186,7 +1107,7 @@ cleanupController:
     # - secretName
 
   # -- (int) Desired number of pods
-  replicas:
+  replicas: ~
 
   # -- Additional labels to add to each pod
   podLabels: {}
@@ -1373,7 +1294,7 @@ cleanupController:
     # -- Additional labels
     additionalLabels: {}
     # -- (string) Override namespace
-    namespace:
+    namespace: ~
     # --  Interval to scrape metrics
     interval: 30s
     # -- Timeout if metrics can't be retrieved in given time interval
@@ -1445,7 +1366,7 @@ reportsController:
     repository: kyverno/reports-controller
     # -- (string) Image tag
     # Defaults to appVersion in Chart.yaml if omitted
-    tag:
+    tag: ~
     # -- Image pull policy
     pullPolicy: IfNotPresent
 
@@ -1454,7 +1375,7 @@ reportsController:
     # - secretName
 
   # -- (int) Desired number of pods
-  replicas:
+  replicas: ~
 
   # -- Additional labels to add to each pod
   podLabels: {}
@@ -1575,7 +1496,7 @@ reportsController:
     type: ClusterIP
     # -- (string) Service node port.
     # Only used if `type` is `NodePort`.
-    nodePort:
+    nodePort: ~
     # -- Service annotations.
     annotations: {}
 
@@ -1594,7 +1515,7 @@ reportsController:
     # -- Additional labels
     additionalLabels: {}
     # -- (string) Override namespace
-    namespace:
+    namespace: ~
     # -- Interval to scrape metrics
     interval: 30s
     # -- Timeout if metrics can't be retrieved in given time interval
@@ -1612,11 +1533,11 @@ reportsController:
     # -- Enable tracing
     enabled: false
     # -- (string) Traces receiver address
-    address:
+    address: ~
     # -- (string) Traces receiver port
-    port:
+    port: ~
     # -- (string) Traces receiver credentials
-    creds:
+    creds: ~
 
   metering:
     # -- Disable metrics export
@@ -1626,6 +1547,6 @@ reportsController:
     # -- Prometheus endpoint port
     port: 8000
     # -- (string) Otel collector endpoint
-    collector:
+    collector: ~
     # -- (string) Otel collector credentials
-    creds:
+    creds: ~

--- a/helm/kyverno/charts/policy-reporter/charts/kyvernoPlugin/values.yaml
+++ b/helm/kyverno/charts/policy-reporter/charts/kyvernoPlugin/values.yaml
@@ -145,7 +145,7 @@ api:
 blockReports:
   enabled: false
   eventNamespace: default
-  results: 
+  results:
     maxPerReport: 200
     keepOnlyLatest: false
 
@@ -174,8 +174,8 @@ networkPolicy:
   enabled: false
   # Kubernetes API Server
   egress:
-  - to:
-    ports:
-    - protocol: TCP
-      port: 6443
+    - to:
+      ports:
+        - protocol: TCP
+          port: 6443
   ingress: []

--- a/helm/kyverno/charts/policy-reporter/charts/monitoring/values.yaml
+++ b/helm/kyverno/charts/policy-reporter/charts/monitoring/values.yaml
@@ -24,7 +24,6 @@ serviceMonitor:
   scrapeTimeout:
   # optional scrape interval
   interval:
-  
 kyverno:
   serviceMonitor:
     # HonorLabels chooses the metrics labels on collisions with target labels

--- a/helm/kyverno/charts/policy-reporter/values.yaml
+++ b/helm/kyverno/charts/policy-reporter/values.yaml
@@ -92,10 +92,10 @@ networkPolicy:
   enabled: false
   # Kubernetes API Server
   egress:
-  - to:
-    ports:
-    - protocol: TCP
-      port: 6443
+    - to:
+      ports:
+        - protocol: TCP
+          port: 6443
   ingress: []
 
 ## Set to true to enable ingress record generation

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -19,7 +19,7 @@ crds:
       memory: 1024Mi
 
 image:
-  registry: docker.io
+  registry: gsoci.azurecr.io
 
 # VerticalPodAutoscaler settings for individual controllers
 verticalPodAutoscaler:
@@ -54,11 +54,12 @@ policyExceptions:
   # of the namespaces listed in allowedPolexNamespaces.
   enablePolexPolicy: true
   allowedPolexNamespaces:
-  - policy-exceptions
+    - policy-exceptions
   # For security reasons, we don't disclose the allowed namespaces when a polex is rejected.
   # The message shown to users can be customized to direct them to an exception process.
   polexPolicyMessage: >-
-    PolicyExceptions are not allowed to be created in the {{ request.namespace }} namespace.
+    PolicyExceptions are not allowed to be created in the {{ request.namespace }}
+    namespace.
     Please contact a cluster administrator for assistance.
   # Deploy a PolicyException for chart-operator (required for Giant Swarm clusters).
   enableChartOperatorPolex: true
@@ -113,7 +114,7 @@ kyverno:
     enableDefaultRegistryMutation: true
 
     # -- The registry hostname used for the image mutation.
-    defaultRegistry: docker.io
+    defaultRegistry: gsoci.azurecr.io
 
     # -- Defines the `namespaceSelector` in the webhook configurations.
     # Note that it takes a list of `namespaceSelector` and/or `objectSelector` in the JSON format, and only the first element
@@ -122,10 +123,10 @@ kyverno:
     webhooks:
       - namespaceSelector:
           matchExpressions:
-          - key: kubernetes.io/metadata.name
-            operator: NotIn
-            values:
-              - kube-system
+            - key: kubernetes.io/metadata.name
+              operator: NotIn
+              values:
+                - kube-system
 
   features:
     admissionReports:
@@ -180,11 +181,11 @@ kyverno:
       allowInsecure: false
       # -- Enable registry client helpers
       credentialHelpers:
-      - default
-      - google
-      - amazon
-      - azure
-      - github
+        - default
+        - google
+        - amazon
+        - azure
+        - github
     reports:
       # -- Reports chunk size
       chunkSize: 1000
@@ -205,7 +206,7 @@ kyverno:
 
       image:
         # -- (string) Image registry
-        registry: docker.io
+        registry: gsoci.azurecr.io
         # -- Image repository
         repository: giantswarm/docker-kubectl
         # -- Image tag
@@ -257,7 +258,7 @@ kyverno:
 
       image:
         # -- (string) Image registry
-        registry: docker.io
+        registry: gsoci.azurecr.io
         # -- Image repository
         repository: giantswarm/docker-kubectl
         # -- Image tag
@@ -419,7 +420,7 @@ kyverno:
 
       image:
         # -- Image registry
-        registry: docker.io
+        registry: gsoci.azurecr.io
         # -- Image repository
         repository: giantswarm/kyvernopre
 
@@ -455,7 +456,7 @@ kyverno:
 
       image:
         # -- Image registry
-        registry: docker.io
+        registry: gsoci.azurecr.io
         # -- Image repository
         repository: giantswarm/kyverno
         # -- Image pull policy
@@ -585,7 +586,7 @@ kyverno:
 
     image:
       # -- (string) Image registry
-      registry: docker.io
+      registry: gsoci.azurecr.io
       # If you want to manage the registry you should remove it from the repository
       # registry: docker.io
       # repository: kyverno/background-controller
@@ -772,7 +773,7 @@ kyverno:
 
     image:
       # -- Image registry
-      registry: docker.io
+      registry: gsoci.azurecr.io
       # -- Image repository
       repository: giantswarm/cleanup-controller
       # -- Image pull policy
@@ -963,7 +964,7 @@ kyverno:
 
     image:
       # -- Image registry
-      registry: docker.io
+      registry: gsoci.azurecr.io
       # -- Image repository
       repository: giantswarm/reports-controller
       # -- Image pull policy
@@ -1124,7 +1125,7 @@ policy-reporter:
   podLabels:
     app.kubernetes.io/component: policy-reporter
   image:
-    registry: docker.io
+    registry: gsoci.azurecr.io
     repository: giantswarm/policy-reporter
   resources:
     limits:
@@ -1141,7 +1142,7 @@ policy-reporter:
     podLabels:
       app.kubernetes.io/component: ui
     image:
-      registry: docker.io
+      registry: gsoci.azurecr.io
       repository: giantswarm/policy-reporter-ui
     plugins:
       kyverno: true
@@ -1162,7 +1163,7 @@ policy-reporter:
     podLabels:
       app.kubernetes.io/component: plugin
     image:
-      registry: docker.io
+      registry: gsoci.azurecr.io
       repository: giantswarm/policy-reporter-kyverno-plugin
     resources:
       limits:


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
