### PR TITLE
Don't push to CAPZ collection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,19 +98,7 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
-      - architect/push-to-app-collection:
-          name: capz-app-collection
-          context: "architect"
-          app_name: "kyverno"
-          app_namespace: "kyverno"
-          app_collection_repo: "capz-app-collection"
-          requires:
-            - push-kyverno-chart-to-control-plane-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
+
       - architect/push-to-app-collection:
           name: gcp-app-collection
           context: "architect"


### PR DESCRIPTION
CAPZ uses default-apps to install the security-bundle, which causes conflicts with collection. We shouldn't push to collection anymore.