### PR TITLE
Allow kyverno-policy-reporter to talk to kyverno-ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Allow `kyverno-policy-reporter` to talk to `kyverno-ui`.
+
 ## [0.17.2] - 2024-01-25
 
 ### Changed

--- a/helm/kyverno/templates/kyverno-cilium/ciliumnetworkpolicy.yaml
+++ b/helm/kyverno/templates/kyverno-cilium/ciliumnetworkpolicy.yaml
@@ -222,4 +222,23 @@ spec:
       - ports:
         - port: "8000"
           protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-kyverno-policy-reporter-talk-to-kyverno-ui
+  namespace: {{ include "kyverno-stack.namespace" . }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: ui
+      app.kubernetes.io/instance: kyverno
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/component: policy-reporter
+      toPorts:
+      - ports:
+        - port: "8080"
+          protocol: TCP
 {{- end }}


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/29581

fixes observed drop:

```
kyverno/kyverno-policy-reporter-99bd697d5-92xjr:44302 (ID:22023) <> kyverno/kyverno-ui-6f67595fdb-5sgt7:8080 (ID:45019) Policy denied DROPPED (TCP Flags: SYN)
```

### Checklist

- [x] Update changelog in CHANGELOG.md.
