### PR TITLE
Disable upgrade jobs for v1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disable v1.10 upgrade jobs. They are not needed when migrating from v1.10 to v1.11+.
+
 ## [0.17.6] - 2024-02-22
 
 ### Fixed

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -92,13 +92,13 @@ policyExceptions:
 
 # Upgrade job for Kyverno < 1.10.0 upgrades.
 upgradeJob:
-  enabled: true
+  enabled: false
 
 # Additional options defined in charts/kyverno/values.yaml. Upstream docs: https://github.com/kyverno/kyverno
 kyverno:
   # Enable upgrade from v2 to v3 chart
   upgrade:
-    fromV2: true
+    fromV2: false
 
   # Create a PSP and ClusterRoleBinding for Kyverno.
   psp:


### PR DESCRIPTION
The upgrade job that downscales Kyverno was only needed for v1.10 upgrades. Now we can safely assume that nobody will run a v1.9 to v1.11 upgrade anymore.