### PR TITLE
Revert "Update gsoci.azurecr.io/giantswarm/kubectl Docker tag to v1.29.3"

### DIFF
--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -39,7 +39,7 @@ image:
   repository: giantswarm/kubectl
   # -- Image tag
   # Defaults to `latest` if omitted
-  tag: '1.29.3'
+  tag: '1.29.2'
 
 # VerticalPodAutoscaler settings for individual controllers
 verticalPodAutoscaler:
@@ -228,7 +228,7 @@ kyverno:
         repository: giantswarm/kubectl
         # -- Image tag
         # Defaults to `latest` if omitted
-        tag: '1.29.3'
+        tag: '1.29.2'
         # -- (string) Image pull policy
         # Defaults to image.pullPolicy if omitted
         pullPolicy: IfNotPresent
@@ -281,7 +281,7 @@ kyverno:
         # -- Image tag
         # Defaults to `latest` if omitted
         # repo: giantswarm/kubectl
-        tag: '1.29.3'
+        tag: '1.29.2'
         # -- (string) Image pull policy
         # Defaults to image.pullPolicy if omitted
         pullPolicy: IfNotPresent
@@ -1153,7 +1153,7 @@ kyverno:
       repository: giantswarm/kubectl
       # -- Image tag
       # Defaults to `latest` if omitted
-      tag: '1.29.3'
+      tag: '1.29.2'
 
   webhooksCleanup:
     image:
@@ -1163,7 +1163,7 @@ kyverno:
       repository: giantswarm/kubectl
       # -- Image tag
       # Defaults to `latest` if omitted
-      tag: '1.29.3'
+      tag: '1.29.2'
 
 # Additional options defined in charts/policy-reporter/values.yaml. Upstream docs: https://github.com/kyverno/policy-reporter
 policy-reporter:


### PR DESCRIPTION
Reverts giantswarm/kyverno-app#368 because the image is not present on Docker yet and some installations are failing.