### PR TITLE
Disable DNS Proxy when not needed

### DIFF
--- a/helm/kyverno/templates/kyverno-cilium/ciliumnetworkpolicy.yaml
+++ b/helm/kyverno/templates/kyverno-cilium/ciliumnetworkpolicy.yaml
@@ -76,15 +76,13 @@ spec:
             protocol: ANY
           - port: "53"
             protocol: ANY
+        {{- if .Values.ciliumNetworkPolicy.admissionControllerExtraEgress.dnsSelector.rules -}}
         rules:
           dns:
-          {{- if .Values.ciliumNetworkPolicy.admissionControllerExtraEgress.dnsSelector.rules -}}
             {{- with .Values.ciliumNetworkPolicy.admissionControllerExtraEgress.dnsSelector.rules -}}
             {{ toYaml . | nindent 10 }}
             {{- end }}
-          {{- else }}
-          - matchPattern: "*"
-          {{- end }}
+        {{- end }}
     # Allow FQDNs connection
     - toFQDNs:
     {{- if .Values.ciliumNetworkPolicy.admissionControllerExtraEgress.fqdnsConnection.rules -}}


### PR DESCRIPTION
Disable the DNS proxying when rules are not specified. This was a recommendation from Cabagge.