### PR TITLE
Update PolicyExceptions to v2beta1

### DIFF
--- a/helm/kyverno/templates/core-policies/aws-cloud-controller-manager-polex.yaml
+++ b/helm/kyverno/templates/core-policies/aws-cloud-controller-manager-polex.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.policyExceptions.enableAwsCloudControllerManagerPolex }}
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: kyverno-app-aws-cloud-controller-policy-exception 

--- a/helm/kyverno/templates/core-policies/aws-ebs-csi-driver-polex.yaml
+++ b/helm/kyverno/templates/core-policies/aws-ebs-csi-driver-polex.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.policyExceptions.enableAwsEbsCsiDriverPolex }}
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: kyverno-app-aws-ebs-csi-driver-policy-exception 

--- a/helm/kyverno/templates/core-policies/azure-cloud-controller-manager-polex.yaml
+++ b/helm/kyverno/templates/core-policies/azure-cloud-controller-manager-polex.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.policyExceptions.enableAzureCloudControllerManagerPolex }}
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: kyverno-app-azure-cloud-controller-policy-exception 

--- a/helm/kyverno/templates/core-policies/azure-cloud-node-manager-polex.yaml
+++ b/helm/kyverno/templates/core-policies/azure-cloud-node-manager-polex.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.policyExceptions.enableAzureCloudNodeManagerPolex }}
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: kyverno-app-azure-cloud-node-manager-policy-exception

--- a/helm/kyverno/templates/core-policies/chart-operator-polex.yaml
+++ b/helm/kyverno/templates/core-policies/chart-operator-polex.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.policyExceptions.enableChartOperatorPolex }}
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: kyverno-app-chart-operator-policy-exception
@@ -30,7 +30,7 @@ spec:
         names:
         - chart-operator*
 ---
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: kyverno-app-chart-operator-sa-policy-exception

--- a/helm/kyverno/templates/core-policies/cilium-polex.yaml
+++ b/helm/kyverno/templates/core-policies/cilium-polex.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.policyExceptions.enableCiliumPolex }}
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: kyverno-app-cilium-policy-exception

--- a/helm/kyverno/templates/core-policies/cilium-policies-polex.yaml
+++ b/helm/kyverno/templates/core-policies/cilium-policies-polex.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.policyExceptions.enableCiliumPolex }}
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: kyverno-app-cilium-policies-policy-exception


### PR DESCRIPTION
### Related issue: https://github.com/giantswarm/giantswarm/issues/30726

## Description

We need to update the PolicyExceptions apiVersion to v2beta1 as v2alpha1 is being removed in the next Kyverno release.
				