### PR TITLE
Enable cleanup-controller by default and update CNP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enable `cleanup-controller` with VericalPodAutoscaler by default.
+- Add missing ingress to `cleanup-controller` CiliumNetworkPolicy.
+
 ## [0.17.10] - 2024-04-30
 
 ### Added

--- a/helm/kyverno/templates/kyverno-cilium/ciliumnetworkpolicy.yaml
+++ b/helm/kyverno/templates/kyverno-cilium/ciliumnetworkpolicy.yaml
@@ -227,6 +227,8 @@ spec:
   ingress:
     - fromEntities:
         - cluster
+        - remote-node
+        - kube-apiserver
       toPorts:
       - ports:
         - port: "9443"

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -50,7 +50,7 @@ verticalPodAutoscaler:
     enabled: true
     containerPolicies: {}
   cleanupController:
-    enabled: false
+    enabled: true
     containerPolicies: {}
   reportsController:
     enabled: true
@@ -765,7 +765,7 @@ kyverno:
     featuresOverride: {}
 
     # -- Enable cleanup controller.
-    enabled: false
+    enabled: true
 
     rbac:
       # -- Create RBAC resources


### PR DESCRIPTION
Enables cleanup-controller by default and adds a missing Ingress to the CNP.