### PR TITLE
Add extra Trivy Operator cleanup policy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   # used by renovate
   # repo: giantswarm/architect-orb
-  architect: giantswarm/architect@dev:2da4dcf167a05bca3e141091710b93772bcdf39c
+  architect: giantswarm/architect@5.1.1
 
 workflows:
   package-and-push-chart-on-tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   # used by renovate
   # repo: giantswarm/architect-orb
-  architect: giantswarm/architect@5.1.1
+  architect: giantswarm/architect@dev:2da4dcf167a05bca3e141091710b93772bcdf39c
 
 workflows:
   package-and-push-chart-on-tag:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add cleanup policy to remove old `trivy-operator` resources.
+
 ### Changed
 
 - Enable `cleanup-controller` with VericalPodAutoscaler by default.

--- a/helm/kyverno/templates/core-policies/trivy-cluster-cleanup-policy.yaml
+++ b/helm/kyverno/templates/core-policies/trivy-cluster-cleanup-policy.yaml
@@ -33,7 +33,7 @@ metadata:
     app.kubernetes.io/component: cleanup-controller
     app.kubernetes.io/instance: kyverno
     app.kubernetes.io/part-of: kyverno
-  name: kyverno:cleanup-rbacassesment
+  name: kyverno:cleanup-trivy-operator-reports
 rules:
 - apiGroups:
   - aquasecurity.github.io

--- a/helm/kyverno/templates/core-policies/trivy-cluster-cleanup-policy.yaml
+++ b/helm/kyverno/templates/core-policies/trivy-cluster-cleanup-policy.yaml
@@ -18,8 +18,8 @@ spec:
           - aquasecurity.github.io/*/ClusterConfigAuditReport
           - aquasecurity.github.io/*/SbomReport
           - aquasecurity.github.io/*/ClusterSbomReport
-          - aquasecurity.github.io/*/InfraAssementReport
-          - aquasecurity.github.io/*/ClusterInfraAssementReport
+          - aquasecurity.github.io/*/InfraAssessmentReport
+          - aquasecurity.github.io/*/ClusterInfraAssessmentReport
           - aquasecurity.github.io/*/VulnerabilityReport
           - aquasecurity.github.io/*/ClusterVulnerabilityReport
           - aquasecurity.github.io/*/ExposedSecretReport
@@ -42,17 +42,17 @@ rules:
 - apiGroups:
   - aquasecurity.github.io
   resources:
-  - RbacAssessmentReport
-  - ClusterRbacAssessmentReport
-  - ConfigAuditReport
-  - ClusterConfigAuditReport
-  - SbomReport
-  - ClusterSbomReport
-  - InfraAssementReport
-  - ClusterInfraAssementReport
-  - VulnerabilityReport
-  - ClusterVulnerabilityReport
-  - ExposedSecretReport
+  - rbacassessmentreports
+  - clusterrbacassessmentreports
+  - configauditreports
+  - clusterconfigauditreports
+  - sbomreports
+  - clustersbomreports
+  - infraassessmentreports
+  - clusterinfraassessmentreports
+  - vulnerabilityreports
+  - clustervulnerabilityreports
+  - exposedsecretreports
   verbs:
   - get
   - watch

--- a/helm/kyverno/templates/core-policies/trivy-cluster-cleanup-policy.yaml
+++ b/helm/kyverno/templates/core-policies/trivy-cluster-cleanup-policy.yaml
@@ -3,6 +3,10 @@ apiVersion: kyverno.io/v2beta1
 kind: ClusterCleanupPolicy
 metadata:
   name: clean-trivy-operator-resources
+  labels:
+    {{- include "kyverno-stack.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
 spec:
   match:
     any:

--- a/helm/kyverno/templates/core-policies/trivy-cluster-cleanup-policy.yaml
+++ b/helm/kyverno/templates/core-policies/trivy-cluster-cleanup-policy.yaml
@@ -12,17 +12,17 @@ spec:
     any:
     - resources:
         kinds:
-          - RbacAssessmentReport.aquasecurity.github.io
-          - ClusterRbacAssessmentReport.aquasecurity.github.io
-          - ConfigAuditReport.aquasecurity.github.io
-          - ClusterConfigAuditReport.aquasecurity.github.io
-          - SbomReport.aquasecurity.github.io
-          - ClusterSbomReport.aquasecurity.github.io
-          - InfraAssementReport.aquasecurity.github.io
-          - ClusterInfraAssementReport.aquasecurity.github.io
-          - VulnerabilityReport.aquasecurity.github.io
-          - ClusterVulnerabilityReport.aquasecurity.github.io
-          - ExposedSecretReport.aquasecurity.github.io
+          - aquasecurity.github.io/*/RbacAssessmentReport
+          - aquasecurity.github.io/*/ClusterRbacAssessmentReport
+          - aquasecurity.github.io/*/ConfigAuditReport
+          - aquasecurity.github.io/*/ClusterConfigAuditReport
+          - aquasecurity.github.io/*/SbomReport
+          - aquasecurity.github.io/*/ClusterSbomReport
+          - aquasecurity.github.io/*/InfraAssementReport
+          - aquasecurity.github.io/*/ClusterInfraAssementReport
+          - aquasecurity.github.io/*/VulnerabilityReport
+          - aquasecurity.github.io/*/ClusterVulnerabilityReport
+          - aquasecurity.github.io/*/ExposedSecretReport
   conditions:
     any:
     - key: "{{`{{ time_since('', '{{target.metadata.creationTimestamp}}', '') }}`}}"

--- a/helm/kyverno/templates/core-policies/trivy-cluster-cleanup-policy.yaml
+++ b/helm/kyverno/templates/core-policies/trivy-cluster-cleanup-policy.yaml
@@ -1,0 +1,57 @@
+{{- if and .Values.cleanupPolicies.trivyOperator.enabled .Values.kyverno.cleanupController.enabled -}}
+apiVersion: kyverno.io/v2beta1
+kind: ClusterCleanupPolicy
+metadata:
+  name: clean-trivy-operator-resources
+spec:
+  match:
+    any:
+    - resources:
+        kinds:
+          - RbacAssessmentReport.aquasecurity.github.io
+          - ClusterRbacAssessmentReport.aquasecurity.github.io
+          - ConfigAuditReport.aquasecurity.github.io
+          - ClusterConfigAuditReport.aquasecurity.github.io
+          - SbomReport.aquasecurity.github.io
+          - ClusterSbomReport.aquasecurity.github.io
+          - InfraAssementReport.aquasecurity.github.io
+          - ClusterInfraAssementReport.aquasecurity.github.io
+          - VulnerabilityReport.aquasecurity.github.io
+          - ClusterVulnerabilityReport.aquasecurity.github.io
+          - ExposedSecretReport.aquasecurity.github.io
+  conditions:
+    any:
+    - key: "{{`{{ time_since('', '{{target.metadata.creationTimestamp}}', '') }}`}}"
+      operator: GreaterThanOrEquals
+      value: {{ default "336h" .Values.cleanupPolicies.trivyOperator.olderThan }}
+  schedule: {{ quote .Values.cleanupPolicies.trivyOperator.schedule }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: cleanup-controller
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/part-of: kyverno
+  name: kyverno:cleanup-rbacassesment
+rules:
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - RbacAssessmentReport
+  - ClusterRbacAssessmentReport
+  - ConfigAuditReport
+  - ClusterConfigAuditReport
+  - SbomReport
+  - ClusterSbomReport
+  - InfraAssementReport
+  - ClusterInfraAssementReport
+  - VulnerabilityReport
+  - ClusterVulnerabilityReport
+  - ExposedSecretReport
+  verbs:
+  - get
+  - watch
+  - list
+  - delete
+{{- end -}}

--- a/helm/kyverno/values.schema.json
+++ b/helm/kyverno/values.schema.json
@@ -40,6 +40,25 @@
                 }
             }
         },
+        "cleanupPolicies": {
+            "type": "object",
+            "properties": {
+                "trivyOperator": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "olderThan": {
+                            "type": "string"
+                        },
+                        "schedule": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "crds": {
             "type": "object",
             "properties": {
@@ -1414,9 +1433,6 @@
                     "type": "object",
                     "properties": {
                         "application.giantswarm.io/team": {
-                            "type": "string"
-                        },
-                        "giantswarm.io/monitoring_basic_sli": {
                             "type": "string"
                         },
                         "giantswarm.io/service-type": {

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -72,7 +72,7 @@ cleanupPolicies:
     # -- Enable Trivy cleanup policy to delete old Trivy Operator reports
     enabled: true
     # -- Cleanup schedule
-    schedule: '0 * * * *'
+    schedule: '37 * * * *'
     # -- Reports older than this duration will be deleted. Needs to be specified in hours. Defaults to 2 weeks (336 hours).
     olderThan: 336h
 

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -67,6 +67,15 @@ verticalPodAutoscaler:
     enabled: true
     containerPolicies: {}
 
+cleanupPolicies:
+  trivyOperator:
+    # -- Enable Trivy cleanup policy to delete old Trivy Operator reports
+    enabled: true
+    # -- Cronjob schedule
+    schedule: '0 * * * *'
+    # -- Reports older than this duration will be deleted. Needs to be specified in hours. Defaults to 2 weeks (336 hours).
+    olderThan: 336h
+
 policyExceptions:
   # Kyverno will accept PolicyExceptions from all namespaces.
   # If enablePolexPolicy is true, this chart will deploy an additional
@@ -765,7 +774,7 @@ kyverno:
     featuresOverride: {}
 
     # -- Enable cleanup controller.
-    enabled: false
+    enabled: true
 
     rbac:
       # -- Create RBAC resources

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -71,7 +71,7 @@ cleanupPolicies:
   trivyOperator:
     # -- Enable Trivy cleanup policy to delete old Trivy Operator reports
     enabled: true
-    # -- Cronjob schedule
+    # -- Cleanup schedule
     schedule: '0 * * * *'
     # -- Reports older than this duration will be deleted. Needs to be specified in hours. Defaults to 2 weeks (336 hours).
     olderThan: 336h


### PR DESCRIPTION
This PR adds a Cleanup Policy to remove old Trivy Operator resources from the cluster.