### PR TITLE
Add `before-hook-creation` to upstream hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Enable `cleanup-controller` with VericalPodAutoscaler by default.
 - Add missing ingress to `cleanup-controller` CiliumNetworkPolicy.
+- Add `before-hook-creation` delete-policy for upstream hooks.
 
 ## [0.17.10] - 2024-04-30
 

--- a/helm/kyverno/charts/kyverno/templates/hooks/post-upgrade.yaml
+++ b/helm/kyverno/charts/kyverno/templates/hooks/post-upgrade.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "kyverno.hooks.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
 spec:
   backoffLimit: 2
   template:

--- a/helm/kyverno/charts/kyverno/templates/hooks/pre-delete.yaml
+++ b/helm/kyverno/charts/kyverno/templates/hooks/pre-delete.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "kyverno.hooks.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-delete
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
 spec:
   backoffLimit: 2
   template:


### PR DESCRIPTION
This has been an issue in some places because Helm doesn't remove the hook before trying to create it again.

It has been fixed upstream here: https://github.com/kyverno/kyverno/commit/2f4b8230304ff3de2001735791eb44ee1e69bedd , but this change will only make it on Kyverno v1.12.