### PR TITLE
Add Helm annotations to core policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Remove duplicated key from the `allow-kyverno-policy-reporter-talk-to-kyverno-ui` CiliumNetworkPolicy.
+- Add Helm annotations to core policies.
 
 ## [0.17.13] - 2024-05-23
 

--- a/helm/kyverno/templates/_helpers.tpl
+++ b/helm/kyverno/templates/_helpers.tpl
@@ -150,6 +150,8 @@ app.kubernetes.io/instance: "{{ template "kyverno-stack.name" . }}"
 
 {{- define "kyverno-stack.policyInstallAnnotations" -}}
 "helm.sh/hook": "post-install,post-upgrade"
+"meta.helm.sh/release-name": {{ .Release.Name | quote }}
+"meta.helm.sh/release-namespace" : {{ .Release.Namespace | quote }}
 {{- end -}}
 
 {{/* Define upgrade job variables */}}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/30018

Adds the needed Helm annotations so these resources can be adopted by the chart in the future