### PR TITLE
Remove Helm hooks annotations from core policies

### DIFF
--- a/helm/kyverno/templates/_helpers.tpl
+++ b/helm/kyverno/templates/_helpers.tpl
@@ -148,12 +148,6 @@ app.kubernetes.io/instance: "{{ template "kyverno-stack.name" . }}"
 {{- printf "%s" "crd-install-hook" -}}
 {{- end -}}
 
-{{- define "kyverno-stack.policyInstallAnnotations" -}}
-"helm.sh/hook": "post-install,post-upgrade"
-"meta.helm.sh/release-name": {{ .Release.Name | quote }}
-"meta.helm.sh/release-namespace" : {{ .Release.Namespace | quote }}
-{{- end -}}
-
 {{/* Define upgrade job variables */}}
 {{- define "kyverno-stack.upgradeJob.name" -}}
 {{- printf "%s-%s" ( include "kyverno-stack.name" . ) "upgrade-job" | replace "+" "_" | trimSuffix "-" -}}

--- a/helm/kyverno/templates/core-policies/aws-cloud-controller-manager-polex.yaml
+++ b/helm/kyverno/templates/core-policies/aws-cloud-controller-manager-polex.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: giantswarm
   labels:
     {{- include "kyverno-stack.labels" . | nindent 4 }}
-  annotations:
-    {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
 spec:
   exceptions:
   - policyName: require-run-as-nonroot

--- a/helm/kyverno/templates/core-policies/aws-ebs-csi-driver-polex.yaml
+++ b/helm/kyverno/templates/core-policies/aws-ebs-csi-driver-polex.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: giantswarm
   labels:
     {{- include "kyverno-stack.labels" . | nindent 4 }}
-  annotations:
-    {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
 spec:
   exceptions:
   - policyName: disallow-host-path

--- a/helm/kyverno/templates/core-policies/azure-cloud-controller-manager-polex.yaml
+++ b/helm/kyverno/templates/core-policies/azure-cloud-controller-manager-polex.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: giantswarm
   labels:
     {{- include "kyverno-stack.labels" . | nindent 4 }}
-  annotations:
-    {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
 spec:
   exceptions:
   - policyName: disallow-host-path

--- a/helm/kyverno/templates/core-policies/azure-cloud-node-manager-polex.yaml
+++ b/helm/kyverno/templates/core-policies/azure-cloud-node-manager-polex.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: giantswarm
   labels:
     {{- include "kyverno-stack.labels" . | nindent 4 }}
-  annotations:
-    {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
 spec:
   exceptions:
   - policyName: require-run-as-nonroot

--- a/helm/kyverno/templates/core-policies/chart-operator-polex.yaml
+++ b/helm/kyverno/templates/core-policies/chart-operator-polex.yaml
@@ -35,8 +35,6 @@ metadata:
   namespace: giantswarm
   labels:
     {{- include "kyverno-stack.labels" . | nindent 4 }}
-  annotations:
-    {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
 spec:
   background: false
   exceptions:

--- a/helm/kyverno/templates/core-policies/chart-operator-polex.yaml
+++ b/helm/kyverno/templates/core-policies/chart-operator-polex.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: giantswarm
   labels:
     {{- include "kyverno-stack.labels" . | nindent 4 }}
-  annotations:
-    {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
 spec:
   exceptions:
   - policyName: disallow-host-ports

--- a/helm/kyverno/templates/core-policies/cilium-agent-polex.yaml
+++ b/helm/kyverno/templates/core-policies/cilium-agent-polex.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: giantswarm
   labels:
     {{- include "kyverno-stack.labels" . | nindent 4 }}
-  annotations:
-    {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
 spec:
   exceptions:
   - policyName: require-non-root-groups

--- a/helm/kyverno/templates/core-policies/cilium-hubble-polex.yaml
+++ b/helm/kyverno/templates/core-policies/cilium-hubble-polex.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: giantswarm
   labels:
     {{- include "kyverno-stack.labels" . | nindent 4 }}
-  annotations:
-    {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
 spec:
   exceptions:
   - policyName: require-run-as-non-root-user

--- a/helm/kyverno/templates/core-policies/cilium-operator-polex.yaml
+++ b/helm/kyverno/templates/core-policies/cilium-operator-polex.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: giantswarm
   labels:
     {{- include "kyverno-stack.labels" . | nindent 4 }}
-  annotations:
-    {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
 spec:
   exceptions:
   - policyName: require-run-as-non-root-user

--- a/helm/kyverno/templates/core-policies/cilium-policies-polex.yaml
+++ b/helm/kyverno/templates/core-policies/cilium-policies-polex.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: giantswarm
   labels:
     {{- include "kyverno-stack.labels" . | nindent 4 }}
-  annotations:
-    {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
 spec:
   exceptions:
   - policyName: require-run-as-non-root-user

--- a/helm/kyverno/templates/core-policies/restrict-polex-namespaces.yaml
+++ b/helm/kyverno/templates/core-policies/restrict-polex-namespaces.yaml
@@ -18,7 +18,6 @@ metadata:
       a PolicyException may be created. This limits the creation of new exceptions,
       but existing exceptions in namespaces other than those allowed here will still
       be honored by Kyverno until they are deleted.
-    {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
 spec:
   validationFailureAction: Enforce
   background: true

--- a/helm/kyverno/templates/core-policies/restrict-policy-kind-wildcards.yaml
+++ b/helm/kyverno/templates/core-policies/restrict-policy-kind-wildcards.yaml
@@ -20,7 +20,6 @@ metadata:
       significant load on Kyverno, and is almost certainly not necessary for a particular policy.
       Please explicitly list the Kinds to be matched by a (Cluster)Policy, or consider whether
       native Kubernetes RBAC can be used instead for policies which truly apply to every type.
-    {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
 spec:
   validationFailureAction: Enforce
   background: true

--- a/helm/kyverno/templates/core-policies/restrict-policy-pod-contexts.yaml
+++ b/helm/kyverno/templates/core-policies/restrict-policy-pod-contexts.yaml
@@ -18,7 +18,6 @@ metadata:
       API calls and external service calls add latency to each admission review, which can compound problems during
       periods of heavy cluster admission activity or CrashLoopBackOffs. When possible, policies requiring external uncached context variables
       should be written for equivalent higher-level controllers (e.g. Deployments instead of Pods), or use a ConfigMap instead.
-    {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
 spec:
   validationFailureAction: Enforce
   background: true

--- a/helm/kyverno/templates/core-policies/trivy-cluster-cleanup-policy.yaml
+++ b/helm/kyverno/templates/core-policies/trivy-cluster-cleanup-policy.yaml
@@ -5,8 +5,6 @@ metadata:
   name: clean-trivy-operator-resources
   labels:
     {{- include "kyverno-stack.labels" . | nindent 4 }}
-  annotations:
-    {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
 spec:
   match:
     any:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/30018

This PR removes the Helm Hooks annotations from the core policies. This will need to be released after #412