### PR TITLE
Adjust VPA and resources for reports, background, and cleanup controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set VPA max 6 CPU / 24Gi memory and adjust default requests/limits for `reports-controller`.
+- Set VPA max 4 CPU / 8Gi memory and adjust default requests/limits for `background-controller`.
+- Set starting CPU limit of request+25% for `cleanup-controller`.
+
 ## [0.17.14] - 2024-06-12
 
 ### Changed

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -48,14 +48,28 @@ verticalPodAutoscaler:
     containerPolicies: {}
   backgroundController:
     enabled: true
-    containerPolicies: {}
+    containerPolicies:
+      - containerName: "*"
+        minAllowed:
+          cpu: 100m
+          memory: 100Mi
+        maxAllowed:
+          cpu: 4
+          memory: 8Gi
   cleanupController:
     enabled: true
     containerPolicies: {}
   reportsController:
     enabled: true
     containerPolicies:
-      controlledResources: ["memory"]
+      - containerName: "*"
+        minAllowed:
+          cpu: 100m
+          memory: 100Mi
+        maxAllowed:
+          cpu: 6
+          memory: 24Gi
+
   # VPA settings for Policy Reporter components
   kyvernoPlugin:
     enabled: true
@@ -659,11 +673,12 @@ kyverno:
     resources:
       # -- Pod resource limits
       limits:
-        memory: 128Mi
+        cpu: 750m
+        memory: 2Gi
       # -- Pod resource requests
       requests:
-        cpu: 100m
-        memory: 64Mi
+        cpu: 500m
+        memory: 1Gi
 
     # -- Node labels for pod assignment
     nodeSelector: {}
@@ -843,6 +858,7 @@ kyverno:
     resources:
       # -- Pod resource limits
       limits:
+        cpu: 125m
         memory: 128Mi
       # -- Pod resource requests
       requests:
@@ -1039,11 +1055,12 @@ kyverno:
     resources:
       # -- Pod resource limits
       limits:
-        memory: 128Mi
+        cpu: 750m
+        memory: 2Gi
       # -- Pod resource requests
       requests:
-        cpu: 100m
-        memory: 64Mi
+        cpu: 500m
+        memory: 1Gi
 
     # -- Node labels for pod assignment
     nodeSelector: {}

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -49,26 +49,24 @@ verticalPodAutoscaler:
   backgroundController:
     enabled: true
     containerPolicies:
-      - containerName: "*"
-        minAllowed:
-          cpu: 100m
-          memory: 100Mi
-        maxAllowed:
-          cpu: 4
-          memory: 8Gi
+      minAllowed:
+        cpu: 100m
+        memory: 100Mi
+      maxAllowed:
+        cpu: 4
+        memory: 8Gi
   cleanupController:
     enabled: true
     containerPolicies: {}
   reportsController:
     enabled: true
     containerPolicies:
-      - containerName: "*"
-        minAllowed:
-          cpu: 100m
-          memory: 100Mi
-        maxAllowed:
-          cpu: 6
-          memory: 24Gi
+      minAllowed:
+        cpu: 100m
+        memory: 100Mi
+      maxAllowed:
+        cpu: 6
+        memory: 24Gi
 
   # VPA settings for Policy Reporter components
   kyvernoPlugin:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29761

It seems trivial but warrants a good think on this one.

Currently, there are no CPU limits for reports-controller or background-controller. These controllers are responsible for performing background scans and processing admission, background, and ephemeral report types. The potential concern is that without sufficient resources, reports may stack up in the cluster and swamp etcd, or there may be delays in report processing that becomes noticeable to users.

This PR:
1. introduces CPU limits for each (requests + 25%, which VPA should maintain)
2. caps VPA to avoid scaling above what can fit on a single node
3. increases starting resources to reduce the likelihood that the controllers would fail to start or get OOMKilled after a fresh installation on larger clusters
4. puts a CPU limit on cleanup-controller

The actual numbers are based on historical usage on some larger clusters.
- Starting resources are still less than the average utilization in large clusters. CPU would be throttled, which is acceptable, but we still run the risk of the controllers being OOMKilled for some time in those environments. There is no technical reason not to align the starting resources with the big cluster average utilization and let VPA scale it down. I haven't done that because I expect other users may be put off by having huge default requests, but haven't ruled it out entirely. Soliciting opinions here.
- The new VPA maximums would still allow some growth in large clusters, but would guarantee that the controllers will fit on a single node of the smallest reasonable type currently under our management.

I will also investigate introducing a business hours alert for cases where these VPA limits are actually reached for an extended period of time.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
