### PR TITLE
Split Cilium policy exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Split Cilium PolicyExceptions per component.
+- Add rules to cilium-agent PolicyException.
+
 ## [0.17.15] - 2024-07-18
 
 ### Changed

--- a/helm/kyverno/templates/core-policies/cilium-agent-polex.yaml
+++ b/helm/kyverno/templates/core-policies/cilium-agent-polex.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.policyExceptions.enableCiliumPolex }}
+apiVersion: kyverno.io/v2beta1
+kind: PolicyException
+metadata:
+  name: kyverno-app-cilium-agent-policy-exception
+  namespace: giantswarm
+  labels:
+    {{- include "kyverno-stack.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
+spec:
+  exceptions:
+  - policyName: require-run-as-non-root-user
+    ruleNames:
+    - run-as-non-root-user 
+    - autogen-run-as-non-root-user
+  - policyName: require-run-as-nonroot 
+    ruleNames:
+    - run-as-non-root 
+    - autogen-run-as-non-root
+  - policyName: disallow-host-path
+    ruleNames:
+    - host-path
+    - autogen-host-path
+  - policyName: restrict-volume-types
+    ruleNames:
+    - restricted-volumes
+    - autogen-restricted-volumes
+  - policyName: disallow-host-namespaces
+    ruleNames:
+    - host-namespaces
+    - autogen-host-namespaces
+  - policyName: restrict-seccomp-strict
+    ruleNames:
+    - check-seccomp-strict
+    - autogen-check-seccomp-strict
+  - policyName: disallow-host-ports
+    ruleNames:
+    - host-ports-none
+    - autogen-host-ports-none
+  - policyName: disallow-capabilities
+    ruleNames:
+    - adding-capabilities
+    - autogen-adding-capabilities
+  - policyName: disallow-capabilities-strict
+    ruleNames:
+    - adding-capabilities-strict
+    - autogen-adding-capabilities-strict
+    - require-drop-all
+    - autogen-require-drop-all
+  - policyName: disallow-privilege-escalation
+    ruleNames:
+    - privilege-escalation
+    - autogen-privilege-escalation
+  - policyName: disallow-selinux
+    ruleNames:
+    - seLinux
+    - selinux-type
+    - autogen-seLinux
+    - autogen-selinux-type
+  - policyName: restrict-apparmor-profiles
+    ruleNames:
+    - app-armor
+    - autogen-app-armor
+  - policyName: disallow-privileged-containers
+    ruleNames:
+    - privileged-containers
+    - autogen-privileged-containers
+  match:
+    any:
+    - resources:
+        kinds:
+        - DaemonSet
+        - Pod
+        namespaces:
+        - kube-system 
+        selector:
+          matchLabels:
+            k8s-app: cilium
+{{- end -}}

--- a/helm/kyverno/templates/core-policies/cilium-agent-polex.yaml
+++ b/helm/kyverno/templates/core-policies/cilium-agent-polex.yaml
@@ -10,6 +10,14 @@ metadata:
     {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
 spec:
   exceptions:
+  - policyName: require-non-root-groups
+    ruleNames:
+    - check-runasgroup
+    - autogen-check-runasgroup
+  - policyName: require-ro-rootfs
+    ruleNames:
+    - validate-read-only-root-filesystem
+    - autogen-validate-read-only-root-filesystem
   - policyName: require-run-as-non-root-user
     ruleNames:
     - run-as-non-root-user 
@@ -48,6 +56,10 @@ spec:
     - autogen-adding-capabilities-strict
     - require-drop-all
     - autogen-require-drop-all
+  - policyName: disallow-capabilities-not-strict
+    ruleNames:
+    - adding-capabilities
+    - autogen-adding-capabilities
   - policyName: disallow-privilege-escalation
     ruleNames:
     - privilege-escalation

--- a/helm/kyverno/templates/core-policies/cilium-hubble-polex.yaml
+++ b/helm/kyverno/templates/core-policies/cilium-hubble-polex.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.policyExceptions.enableCiliumPolex }}
+apiVersion: kyverno.io/v2beta1
+kind: PolicyException
+metadata:
+  name: kyverno-app-cilium-hubble-policy-exception
+  namespace: giantswarm
+  labels:
+    {{- include "kyverno-stack.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kyverno-stack.policyInstallAnnotations" . | nindent 4 }}
+spec:
+  exceptions:
+  - policyName: require-run-as-non-root-user
+    ruleNames:
+    - run-as-non-root-user 
+    - autogen-run-as-non-root-user
+  - policyName: require-run-as-nonroot 
+    ruleNames:
+    - run-as-non-root 
+    - autogen-run-as-non-root
+  - policyName: disallow-host-path
+    ruleNames:
+    - host-path
+    - autogen-host-path
+  - policyName: restrict-volume-types
+    ruleNames:
+    - restricted-volumes
+    - autogen-restricted-volumes
+  - policyName: disallow-host-namespaces
+    ruleNames:
+    - host-namespaces
+    - autogen-host-namespaces
+  - policyName: restrict-seccomp-strict
+    ruleNames:
+    - check-seccomp-strict
+    - autogen-check-seccomp-strict
+  - policyName: disallow-host-ports
+    ruleNames:
+    - host-ports-none
+    - autogen-host-ports-none
+  - policyName: disallow-capabilities
+    ruleNames:
+    - adding-capabilities
+    - autogen-adding-capabilities
+  - policyName: disallow-capabilities-strict
+    ruleNames:
+    - adding-capabilities-strict
+    - autogen-adding-capabilities-strict
+    - require-drop-all
+    - autogen-require-drop-all
+  - policyName: disallow-privilege-escalation
+    ruleNames:
+    - privilege-escalation
+    - autogen-privilege-escalation
+  - policyName: disallow-selinux
+    ruleNames:
+    - seLinux
+    - selinux-type
+    - autogen-seLinux
+    - autogen-selinux-type
+  - policyName: restrict-apparmor-profiles
+    ruleNames:
+    - app-armor
+    - autogen-app-armor
+  - policyName: disallow-privileged-containers
+    ruleNames:
+    - privileged-containers
+    - autogen-privileged-containers
+  match:
+    any:
+    - resources:
+        kinds:
+        - Deployment
+        - ReplicaSet
+        - Pod
+        namespaces:
+        - kube-system 
+        names:
+        - hubble*
+{{- end -}}

--- a/helm/kyverno/templates/core-policies/cilium-operator-polex.yaml
+++ b/helm/kyverno/templates/core-policies/cilium-operator-polex.yaml
@@ -2,7 +2,7 @@
 apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
-  name: kyverno-app-cilium-policy-exception
+  name: kyverno-app-cilium-operator-policy-exception
   namespace: giantswarm
   labels:
     {{- include "kyverno-stack.labels" . | nindent 4 }}
@@ -66,20 +66,15 @@ spec:
     ruleNames:
     - privileged-containers
     - autogen-privileged-containers
-
   match:
     any:
     - resources:
         kinds:
-        - DaemonSet
         - Deployment
         - ReplicaSet
         - Pod
         namespaces:
         - kube-system 
         names:
-        - cilium*
-        - cilium-agent*
         - cilium-operator*
-        - hubble*
 {{- end -}}


### PR DESCRIPTION
This PR split cilium polex per components and adds rule exceptions for the cilium-agent. Towards https://github.com/giantswarm/giantswarm/issues/31178

In the future, we'll remove the cilium-hubble polex and trim down the cilium-operator polex, as we solved several issues in the latest app version (https://github.com/giantswarm/giantswarm/issues/31475)

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
