### PR TITLE
Enable CRDs in ATS tests

### DIFF
--- a/.ats/main.yaml
+++ b/.ats/main.yaml
@@ -1,3 +1,5 @@
+app-tests-app-config-file: tests/test-values.yaml
+
 smoke-tests-cluster-type: kind
 smoke-tests-cluster-config-file: tests/ats/kind_config.yaml
 

--- a/tests/test-values.yaml
+++ b/tests/test-values.yaml
@@ -1,0 +1,2 @@
+crds:
+  install: true


### PR DESCRIPTION
CI is broken due the split of the CRDs into its own App. Unfortunately
ATS doesn't support multiple apps installation, so it has to be done
in code.
This re-enables the in-app CRDs installation only for testing as a
workaround until tests can be fixed properly.

Signed-off-by: Matias Charriere <matias@giantswarm.io>

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
