### PR TITLE
Policy wildcards should be restricted by GVK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Restrict Policy and ClusterPolicy to kyverno.io/v1 for wildcard policy matching
-
 ### Changed
 
 - Split Cilium PolicyExceptions per component.
 - Add rules to cilium-agent PolicyException.
+- Restrict Policy and ClusterPolicy to kyverno.io/v1 for wildcard policy matching
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Restrict Policy and ClusterPolicy to kyverno.io/v1 for wildcard policy matching
+
 ### Changed
 
 - Split Cilium PolicyExceptions per component.

--- a/helm/kyverno/templates/core-policies/restrict-policy-kind-wildcards.yaml
+++ b/helm/kyverno/templates/core-policies/restrict-policy-kind-wildcards.yaml
@@ -29,8 +29,8 @@ spec:
         any:
         - resources:
             kinds:
-              - Policy
-              - ClusterPolicy
+              - kyverno.io/v1/Policy
+              - kyverno.io/v1/ClusterPolicy
       preconditions:
         all:
         - key: "{{`{{ request.operation || 'BACKGROUND' }}`}}"


### PR DESCRIPTION
Crossplane introduces types of `Policy` which are not related to kyverno but get blocked by the wildcard policy which then does not understand them.

To support crossplane co-existing, this change restricts the wildcard policy to the GVK for types Policy and ClusterPolicy

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
