### PR TITLE
Stop pushing to control-plane catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,13 +85,3 @@ workflows:
             ignore:
             - main
             - master
-    # - architect/run-tests-with-ats:
-    #     name: execute chart tests
-    #     filters:
-    #         # Do not trigger the job on merge to main.
-    #       branches:
-    #         ignore:
-    #         - main
-    #     requires:
-    #     - push-kyverno-chart-to-giantswarm-catalog
-    #     - setup-kind


### PR DESCRIPTION
Since Kyverno is a default app now, it is not needed to have it in the control-plane catalog.