### PR TITLE
add support for kamaji CNP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for Kamaji.
+
 ## [0.22.0] - 2025-12-09
 
 ### Changed

--- a/helm/kyverno/templates/kyverno-cilium/ciliumnetworkpolicy.yaml
+++ b/helm/kyverno/templates/kyverno-cilium/ciliumnetworkpolicy.yaml
@@ -326,4 +326,26 @@ spec:
             protocol: TCP
           - port: "6443"
             protocol: TCP
+{{- if .Values.kamaji.enabled }}
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-ingress-from-konnectivity
+  namespace: kyverno
+spec:
+  endpointSelector:
+    matchLabels:
+      # Targets the Kyverno Admission Controller pods
+      app.kubernetes.io/component: admission-controller
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            # Allows traffic from the Konnectivity Agent in kube-system
+            "k8s:io.kubernetes.pod.namespace": kube-system
+            k8s-app: konnectivity-agent
+      toPorts:
+        - ports:
+            - port: "9443"
+{{- end }}
 {{- end }}

--- a/helm/kyverno/values.schema.json
+++ b/helm/kyverno/values.schema.json
@@ -129,6 +129,16 @@
                 }
             }
         },
+        "kamaji": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": "false",
+                    "description": "Does the control plane run as pods in the MC."
+                }
+            }
+        },
         "kyverno": {
             "type": "object",
             "properties": {

--- a/helm/kyverno/values.yaml
+++ b/helm/kyverno/values.yaml
@@ -41,6 +41,9 @@ image:
   # Defaults to `latest` if omitted
   tag: &kubectlTag 'v1.34.3'
 
+kamaji:
+  enabled: false
+
 # VerticalPodAutoscaler settings for individual controllers
 verticalPodAutoscaler:
   admissionController:


### PR DESCRIPTION
Towards https://github.com/giantswarm/cluster-vsphere/pull/441

Kamaji enabled clusters need a component called konnectivity so the CP pods can communicate with the nodes. These require CNP.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
