### PR TITLE
chore: drop inline vendir customManager

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,18 +6,6 @@
     'github>giantswarm/renovate-presets:disable-upstream-charts.json5',
   ],
   automerge: true,
-  customManagers: [
-    {
-      customType: 'regex',
-      managerFilePatterns: [
-        '/(^|/)vendir\\.yml$/',
-      ],
-      matchStrings: [
-        '# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\n]+)\\n\\s+ref: (?<currentValue>[^\\n]+)',
-      ],
-      versioningTemplate: 'semver',
-    },
-  ],
   packageRules: [
     {
       description: 'Automerge architect updates',


### PR DESCRIPTION
The vendir `customManager` and its matching `packageRule` (`branchPrefix`, `prCreation`) are now provided by `giantswarm/renovate-presets:default.json5` (renovate-presets#99). The inline copy is a duplicate once that PR lands.

The repo-specific `groupName: kyverno-upstream` is kept in the vendir `packageRule` since the preset does not set a groupName.

Merge after renovate-presets#99.